### PR TITLE
Add adjust_millis_forward() API to help with deep sleep processing

### DIFF
--- a/cores/arduino/delay.h
+++ b/cores/arduino/delay.h
@@ -36,6 +36,17 @@ extern "C" {
 extern uint32_t millis( void ) ;
 
 /**
+ * \brief Atomically adjust the millis() clock forward.
+ *
+ * \param delta is the value to add to the clock (uint32_t)
+ *
+ * \return New value of the millis() clock.
+ *
+ * \note See also millis(). Overflows are ignored.
+ */
+extern uint32_t adjust_millis_forward( uint32_t );
+
+/**
  * \brief Returns the number of microseconds since the Arduino board began running the current program.
  *
  * This number will overflow (go back to zero), after approximately 70 minutes. On 16 MHz Arduino boards


### PR DESCRIPTION
This patch fixes https://github.com/mcci-catena/ArduinoCore-samd/issues/1.  During a deep sleep, systick must be off. But some libraries use `millis()` to get an idea of real time. (In particular, this is true for https://github.com/mcci-catena/arduino-lmic -- otherwise, it loses track of the schedule.) Since `_ulTickCount` is local to delay.c, the appropriate correction is to add a new API `adjust_millis_forward()`. 

The submitted patch disables interrupts briefly. I have different, tested, patch that instead causes the systick interrupt processor to do the adjustment. But I think the submitted approach is more clear, and is certainly more efficient. It would be great if this could be added to the mainline distribution. (Of course, this might also imply a similar change to the AVR core, and there are portability issues related to the function of the real-time clock which I have not addressed.)

Sample (somewhat clumsy use):
```c++
// Set an alarm in the future.
gRtc.SetAlarm(SLEEP_TIME_IN_SECONDS);

// Deep sleep until the alarm
gRtc.SleepForAlarm(gRtc.MATCH_HHMMSS, gRtc.SleepMode:IdleCpuAhbApb);

// At this point, approximately 1000 * SLEEP_TIME_IN_SECONDS ms have passed without interrupts. 
// Advance the value of millis() accordingly.
// (A more refined approach would take into account fractional seconds.)
adjust_millis_forward(SLEEP_TIME_IN_SECONDS * 1000);
```