### PR TITLE
update clocks to match arduino samd

### DIFF
--- a/cores/arduino/startup.c
+++ b/cores/arduino/startup.c
@@ -263,248 +263,257 @@ void SystemInit( void )
 
 	
   /* Set 1 Flash Wait State for 48MHz, cf tables 20.9 and 35.27 in SAMD21 Datasheet */
-  NVMCTRL->CTRLB.bit.RWS = NVMCTRL_CTRLB_RWS_HALF_Val ;
+    NVMCTRL->CTRLB.bit.RWS = NVMCTRL_CTRLB_RWS_HALF_Val ;
 
-  /* Turn on the digital interface clock */
-  PM->APBAMASK.reg |= PM_APBAMASK_GCLK ;
-  
+    /* Turn on the digital interface clock */
+    PM->APBAMASK.reg |= PM_APBAMASK_GCLK ;
+
+
   #if defined(CRYSTALLESS)
-  /* ----------------------------------------------------------------------------------------------
-   * 1) Enable OSC32K clock (Internal 32.768Hz oscillator)
-   */
 
-  uint32_t calib = (*((uint32_t *) FUSES_OSC32K_CAL_ADDR) & FUSES_OSC32K_CAL_Msk) >> FUSES_OSC32K_CAL_Pos;
+    /* ----------------------------------------------------------------------------------------------
+     * 1) Enable OSC32K clock (Internal 32.768Hz oscillator)
+     */
 
-  SYSCTRL->OSC32K.reg = SYSCTRL_OSC32K_CALIB(calib) |
-                        SYSCTRL_OSC32K_STARTUP( 0x6u ) | // cf table 15.10 of product datasheet in chapter 15.8.6
-                        SYSCTRL_OSC32K_EN32K |
-                        SYSCTRL_OSC32K_ENABLE;
+    uint32_t calib = (*((uint32_t *) FUSES_OSC32K_CAL_ADDR) & FUSES_OSC32K_CAL_Msk) >> FUSES_OSC32K_CAL_Pos;
 
-  while ( (SYSCTRL->PCLKSR.reg & SYSCTRL_PCLKSR_OSC32KRDY) == 0 ); // Wait for oscillator stabilization
+    SYSCTRL->OSC32K.reg = SYSCTRL_OSC32K_CALIB(calib) |
+                          SYSCTRL_OSC32K_STARTUP( 0x6u ) | // cf table 15.10 of product datasheet in chapter 15.8.6
+                          SYSCTRL_OSC32K_EN32K |
+                          SYSCTRL_OSC32K_ENABLE;
 
-	#else // has crystal
+    while ( (SYSCTRL->PCLKSR.reg & SYSCTRL_PCLKSR_OSC32KRDY) == 0 ); // Wait for oscillator stabilization
 
-			/* ----------------------------------------------------------------------------------------------
-			* 1) Enable XOSC32K clock (External on-board 32.768Hz oscillator)
-			*/
+  #else // has crystal
 
-			SYSCTRL->XOSC32K.reg = SYSCTRL_XOSC32K_STARTUP( 0x6u ) | /* cf table 15.10 of product datasheet in chapter 15.8.6 */
-									SYSCTRL_XOSC32K_XTALEN | SYSCTRL_XOSC32K_EN32K ;
-			SYSCTRL->XOSC32K.bit.ENABLE = 1 ; /* separate call, as described in chapter 15.6.3 */
+    /* ----------------------------------------------------------------------------------------------
+     * 1) Enable XOSC32K clock (External on-board 32.768Hz oscillator)
+     */
+    SYSCTRL->XOSC32K.reg = SYSCTRL_XOSC32K_STARTUP( 0x6u ) | /* cf table 15.10 of product datasheet in chapter 15.8.6 */
+                           SYSCTRL_XOSC32K_XTALEN | SYSCTRL_XOSC32K_EN32K ;
+    SYSCTRL->XOSC32K.bit.ENABLE = 1 ; /* separate call, as described in chapter 15.6.3 */
 
-			while ( (SYSCTRL->PCLKSR.reg & SYSCTRL_PCLKSR_XOSC32KRDY) == 0 )
-			{
-			/* Wait for oscillator stabilization */
-			}
+    while ( (SYSCTRL->PCLKSR.reg & SYSCTRL_PCLKSR_XOSC32KRDY) == 0 )
+    {
+      /* Wait for oscillator stabilization */
+    }
 
-	#endif //CRYSTALLESS
+  #endif
 
-  /* Software reset the module to ensure it is re-initialized correctly */
-  
-  /* Note: Due to synchronization, there is a delay from writing CTRL.SWRST until the reset is complete.
-   * CTRL.SWRST and STATUS.SYNCBUSY will both be cleared when the reset is complete, as described in chapter 13.8.1
-   */
-  GCLK->CTRL.reg = GCLK_CTRL_SWRST ;
+    /* Software reset the module to ensure it is re-initialized correctly */
+    /* Note: Due to synchronization, there is a delay from writing CTRL.SWRST until the reset is complete.
+     * CTRL.SWRST and STATUS.SYNCBUSY will both be cleared when the reset is complete, as described in chapter 13.8.1
+     */
+    GCLK->CTRL.reg = GCLK_CTRL_SWRST ;
 
-  while ( (GCLK->CTRL.reg & GCLK_CTRL_SWRST) && (GCLK->STATUS.reg & GCLK_STATUS_SYNCBUSY) )
-  {
-    /* Wait for reset to complete */
-  }
+    while ( (GCLK->CTRL.reg & GCLK_CTRL_SWRST) && (GCLK->STATUS.reg & GCLK_STATUS_SYNCBUSY) )
+    {
+      /* Wait for reset to complete */
+    }
 
-  /* ----------------------------------------------------------------------------------------------
-   * 2) Put XOSC32K as source of Generic Clock Generator 1
-   */
-  GCLK->GENDIV.reg = GCLK_GENDIV_ID( GENERIC_CLOCK_GENERATOR_XOSC32K ) ; // Generic Clock Generator 1
+    /* ----------------------------------------------------------------------------------------------
+     * 2) Put XOSC32K as source of Generic Clock Generator 1
+     */
+    GCLK->GENDIV.reg = GCLK_GENDIV_ID( GENERIC_CLOCK_GENERATOR_XOSC32K ) ; // Generic Clock Generator 1
 
-  while ( GCLK->STATUS.reg & GCLK_STATUS_SYNCBUSY )
-  {
-    /* Wait for synchronization */
-  }
+    while ( GCLK->STATUS.reg & GCLK_STATUS_SYNCBUSY )
+    {
+      /* Wait for synchronization */
+    }
 
-  /* Write Generic Clock Generator 1 configuration */
-  GCLK->GENCTRL.reg = GCLK_GENCTRL_ID( GENERIC_CLOCK_GENERATOR_OSC32K ) | // Generic Clock Generator 1
-	#if defined(CRYSTALLESS)
-						  GCLK_GENCTRL_SRC_OSC32K | // Selected source is Internal 32KHz Oscillator
-	#else
-						  GCLK_GENCTRL_SRC_XOSC32K | // Selected source is External 32KHz Oscillator
-	#endif
-	//                      GCLK_GENCTRL_OE | // Output clock to a pin for tests
-						  GCLK_GENCTRL_GENEN ;
+    /* Write Generic Clock Generator 1 configuration */
+    GCLK->GENCTRL.reg = GCLK_GENCTRL_ID( GENERIC_CLOCK_GENERATOR_OSC32K ) | // Generic Clock Generator 1
+  #if defined(CRYSTALLESS)
+                        GCLK_GENCTRL_SRC_OSC32K | // Selected source is Internal 32KHz Oscillator
+  #else
+                        GCLK_GENCTRL_SRC_XOSC32K | // Selected source is External 32KHz Oscillator
+  #endif
+  //                      GCLK_GENCTRL_OE | // Output clock to a pin for tests
+                        GCLK_GENCTRL_GENEN ;
 
-  while ( GCLK->STATUS.reg & GCLK_STATUS_SYNCBUSY )
-  {
-    /* Wait for synchronization */
-  }
+    while ( GCLK->STATUS.reg & GCLK_STATUS_SYNCBUSY )
+    {
+      /* Wait for synchronization */
+    }
 
-  /* ----------------------------------------------------------------------------------------------
-   * 3) Put Generic Clock Generator 1 as source for Generic Clock Multiplexer 0 (DFLL48M reference)
-   */
-  GCLK->CLKCTRL.reg = GCLK_CLKCTRL_ID( GENERIC_CLOCK_MULTIPLEXER_DFLL48M ) | // Generic Clock Multiplexer 0
-                      GCLK_CLKCTRL_GEN_GCLK1 | // Generic Clock Generator 1 is source
-                      GCLK_CLKCTRL_CLKEN ;
+    /* ----------------------------------------------------------------------------------------------
+     * 3) Put Generic Clock Generator 1 as source for Generic Clock Multiplexer 0 (DFLL48M reference)
+     */
+    GCLK->CLKCTRL.reg = GCLK_CLKCTRL_ID( GENERIC_CLOCK_MULTIPLEXER_DFLL48M ) | // Generic Clock Multiplexer 0
+                        GCLK_CLKCTRL_GEN_GCLK1 | // Generic Clock Generator 1 is source
+                        GCLK_CLKCTRL_CLKEN ;
 
-  while ( GCLK->STATUS.reg & GCLK_STATUS_SYNCBUSY )
-  {
-    /* Wait for synchronization */
-  }
-  /* ----------------------------------------------------------------------------------------------
-   * 4) Enable DFLL48M clock
-   */
+    while ( GCLK->STATUS.reg & GCLK_STATUS_SYNCBUSY )
+    {
+      /* Wait for synchronization */
+    }
 
-  /* DFLL Configuration in Closed Loop mode, cf product datasheet chapter 15.6.7.1 - Closed-Loop Operation */
+    /* ----------------------------------------------------------------------------------------------
+     * 4) Enable DFLL48M clock
+     */
 
-  /* Remove the OnDemand mode, Bug http://avr32.icgroup.norway.atmel.com/bugzilla/show_bug.cgi?id=9905 */
-  SYSCTRL->DFLLCTRL.bit.ONDEMAND = 0 ;
+    /* DFLL Configuration in Closed Loop mode, cf product datasheet chapter 15.6.7.1 - Closed-Loop Operation */
 
-  while ( (SYSCTRL->PCLKSR.reg & SYSCTRL_PCLKSR_DFLLRDY) == 0 )
-  {
-    /* Wait for synchronization */
-  }
+    /* Remove the OnDemand mode, Bug http://avr32.icgroup.norway.atmel.com/bugzilla/show_bug.cgi?id=9905 */
+    SYSCTRL->DFLLCTRL.reg = SYSCTRL_DFLLCTRL_ENABLE;
 
-  SYSCTRL->DFLLMUL.reg = SYSCTRL_DFLLMUL_CSTEP( 31 ) | // Coarse step is 31, half of the max value
-                         SYSCTRL_DFLLMUL_FSTEP( 511 ) | // Fine step is 511, half of the max value
-                         SYSCTRL_DFLLMUL_MUL( (VARIANT_MCK/VARIANT_MAINOSC) ) ; // External 32KHz is the reference
+    while ( (SYSCTRL->PCLKSR.reg & SYSCTRL_PCLKSR_DFLLRDY) == 0 )
+    {
+      /* Wait for synchronization */
+    }
 
-  while ( (SYSCTRL->PCLKSR.reg & SYSCTRL_PCLKSR_DFLLRDY) == 0 )
-  {
-    /* Wait for synchronization */
-  }
+    SYSCTRL->DFLLMUL.reg = SYSCTRL_DFLLMUL_CSTEP( 31 ) | // Coarse step is 31, half of the max value
+                           SYSCTRL_DFLLMUL_FSTEP( 511 ) | // Fine step is 511, half of the max value
+                           SYSCTRL_DFLLMUL_MUL( (VARIANT_MCK + VARIANT_MAINOSC/2) / VARIANT_MAINOSC ) ; // External 32KHz is the reference
 
-	#if defined(CRYSTALLESS)
+    while ( (SYSCTRL->PCLKSR.reg & SYSCTRL_PCLKSR_DFLLRDY) == 0 )
+    {
+      /* Wait for synchronization */
+    }
 
-	  #define NVM_SW_CALIB_DFLL48M_COARSE_VAL 58
-	  #define NVM_SW_CALIB_DFLL48M_FINE_VAL   64
+  #if defined(CRYSTALLESS)
 
-	  // Turn on DFLL
-	  uint32_t coarse =( *((uint32_t *)(NVMCTRL_OTP4) + (NVM_SW_CALIB_DFLL48M_COARSE_VAL / 32)) >> (NVM_SW_CALIB_DFLL48M_COARSE_VAL % 32) )
-					   & ((1 << 6) - 1);
-	  if (coarse == 0x3f) {
-		coarse = 0x1f;
-	  }
-	  uint32_t fine =( *((uint32_t *)(NVMCTRL_OTP4) + (NVM_SW_CALIB_DFLL48M_FINE_VAL / 32)) >> (NVM_SW_CALIB_DFLL48M_FINE_VAL % 32) )
-					 & ((1 << 10) - 1);
-	  if (fine == 0x3ff) {
-		fine = 0x1ff;
-	  }
+    #define NVM_SW_CALIB_DFLL48M_COARSE_VAL 58
 
-	  SYSCTRL->DFLLVAL.bit.COARSE = coarse;
-	  SYSCTRL->DFLLVAL.bit.FINE = fine;
-	  /* Write full configuration to DFLL control register */
-	  SYSCTRL->DFLLCTRL.reg =  SYSCTRL_DFLLCTRL_USBCRM | /* USB correction */
-							   SYSCTRL_DFLLCTRL_CCDIS |
-							   SYSCTRL_DFLLCTRL_WAITLOCK |
-							   SYSCTRL_DFLLCTRL_QLDIS ; /* Disable Quick lock */
+    // Turn on DFLL
+    uint32_t coarse =( *((uint32_t *)(NVMCTRL_OTP4) + (NVM_SW_CALIB_DFLL48M_COARSE_VAL / 32)) >> (NVM_SW_CALIB_DFLL48M_COARSE_VAL % 32) )
+                     & ((1 << 6) - 1);
+    if (coarse == 0x3f) {
+      coarse = 0x1f;
+    }
+    // TODO(tannewt): Load this value from memory we've written previously. There
+    // isn't a value from the Atmel factory.
+    uint32_t fine = 0x1ff;
 
-	  while ( (SYSCTRL->PCLKSR.reg & SYSCTRL_PCLKSR_DFLLRDY) == 0 )
-	  {
-		/* Wait for synchronization */
-	  }
+    SYSCTRL->DFLLVAL.bit.COARSE = coarse;
+    SYSCTRL->DFLLVAL.bit.FINE = fine;
+    /* Write full configuration to DFLL control register */
+    SYSCTRL->DFLLMUL.reg = SYSCTRL_DFLLMUL_CSTEP( 0x1f / 4 ) | // Coarse step is 31, half of the max value
+                           SYSCTRL_DFLLMUL_FSTEP( 10 ) |
+                           SYSCTRL_DFLLMUL_MUL( (48000) ) ;
 
-	  /* Enable the DFLL */
-	  SYSCTRL->DFLLCTRL.reg |= SYSCTRL_DFLLCTRL_ENABLE ;
+    SYSCTRL->DFLLCTRL.reg = 0;
 
-	#else   // has crystal
+    while ( (SYSCTRL->PCLKSR.reg & SYSCTRL_PCLKSR_DFLLRDY) == 0 )
+    {
+      /* Wait for synchronization */
+    }
 
-	  /* Write full configuration to DFLL control register */
-	  SYSCTRL->DFLLCTRL.reg |= SYSCTRL_DFLLCTRL_MODE | /* Enable the closed loop mode */
-							   SYSCTRL_DFLLCTRL_WAITLOCK |
-							   SYSCTRL_DFLLCTRL_QLDIS ; /* Disable Quick lock */
+    SYSCTRL->DFLLCTRL.reg =  SYSCTRL_DFLLCTRL_MODE |
+                             SYSCTRL_DFLLCTRL_CCDIS |
+                             SYSCTRL_DFLLCTRL_USBCRM | /* USB correction */
+                             SYSCTRL_DFLLCTRL_BPLCKC;
 
-	  while ( (SYSCTRL->PCLKSR.reg & SYSCTRL_PCLKSR_DFLLRDY) == 0 )
-	  {
-		/* Wait for synchronization */
-	  }
+    while ( (SYSCTRL->PCLKSR.reg & SYSCTRL_PCLKSR_DFLLRDY) == 0 )
+    {
+      /* Wait for synchronization */
+    }
 
-	  /* Enable the DFLL */
-	  SYSCTRL->DFLLCTRL.reg |= SYSCTRL_DFLLCTRL_ENABLE ;
+    /* Enable the DFLL */
+    SYSCTRL->DFLLCTRL.reg |= SYSCTRL_DFLLCTRL_ENABLE ;
 
-	  while ( (SYSCTRL->PCLKSR.reg & SYSCTRL_PCLKSR_DFLLLCKC) == 0 ||
-			  (SYSCTRL->PCLKSR.reg & SYSCTRL_PCLKSR_DFLLLCKF) == 0 )
-	  {
-		/* Wait for locks flags */
-	  }
+  #else   // has crystal
 
-	#endif //crystalless
+    /* Write full configuration to DFLL control register */
+    SYSCTRL->DFLLCTRL.reg |= SYSCTRL_DFLLCTRL_MODE | /* Enable the closed loop mode */
+                             SYSCTRL_DFLLCTRL_WAITLOCK |
+                             SYSCTRL_DFLLCTRL_QLDIS ; /* Disable Quick lock */
 
-  while ( (SYSCTRL->PCLKSR.reg & SYSCTRL_PCLKSR_DFLLRDY) == 0 )
-  {
-    /* Wait for synchronization */
-  }
+    while ( (SYSCTRL->PCLKSR.reg & SYSCTRL_PCLKSR_DFLLRDY) == 0 )
+    {
+      /* Wait for synchronization */
+    }
 
-  /* ----------------------------------------------------------------------------------------------
-   * 5) Switch Generic Clock Generator 0 to DFLL48M. CPU will run at 48MHz.
-   */
-  GCLK->GENDIV.reg = GCLK_GENDIV_ID( GENERIC_CLOCK_GENERATOR_MAIN ) ; // Generic Clock Generator 0
+    /* Enable the DFLL */
+    SYSCTRL->DFLLCTRL.reg |= SYSCTRL_DFLLCTRL_ENABLE ;
 
-  while ( GCLK->STATUS.reg & GCLK_STATUS_SYNCBUSY )
-  {
-    /* Wait for synchronization */
-  }
+    while ( (SYSCTRL->PCLKSR.reg & SYSCTRL_PCLKSR_DFLLLCKC) == 0 ||
+            (SYSCTRL->PCLKSR.reg & SYSCTRL_PCLKSR_DFLLLCKF) == 0 )
+    {
+      /* Wait for locks flags */
+    }
 
-  /* Write Generic Clock Generator 0 configuration */
-  GCLK->GENCTRL.reg = GCLK_GENCTRL_ID( GENERIC_CLOCK_GENERATOR_MAIN ) | // Generic Clock Generator 0
-                      GCLK_GENCTRL_SRC_DFLL48M | // Selected source is DFLL 48MHz
-//                      GCLK_GENCTRL_OE | // Output clock to a pin for tests
-                      GCLK_GENCTRL_IDC | // Set 50/50 duty cycle
-                      GCLK_GENCTRL_GENEN ;
+  #endif
 
-  while ( GCLK->STATUS.reg & GCLK_STATUS_SYNCBUSY )
-  {
-    /* Wait for synchronization */
-  }
-  
-  /* ----------------------------------------------------------------------------------------------
-   * 6) Modify PRESCaler value of OSC8M to have 8MHz
-   */
-  SYSCTRL->OSC8M.bit.PRESC = SYSCTRL_OSC8M_PRESC_0_Val ;  //CMSIS 4.5 changed the prescaler defines
-  SYSCTRL->OSC8M.bit.ONDEMAND = 0 ;
+    while ( (SYSCTRL->PCLKSR.reg & SYSCTRL_PCLKSR_DFLLRDY) == 0 )
+    {
+      /* Wait for synchronization */
+    }
 
-  /* ----------------------------------------------------------------------------------------------
-   * 7) Put OSC8M as source for Generic Clock Generator 3
-   */
-  GCLK->GENDIV.reg = GCLK_GENDIV_ID( GENERIC_CLOCK_GENERATOR_OSC8M ) ; // Generic Clock Generator 3
+    /* ----------------------------------------------------------------------------------------------
+     * 5) Switch Generic Clock Generator 0 to DFLL48M. CPU will run at 48MHz.
+     */
+    GCLK->GENDIV.reg = GCLK_GENDIV_ID( GENERIC_CLOCK_GENERATOR_MAIN ) ; // Generic Clock Generator 0
 
-  /* Write Generic Clock Generator 3 configuration */
-  GCLK->GENCTRL.reg = GCLK_GENCTRL_ID( GENERIC_CLOCK_GENERATOR_OSC8M ) | // Generic Clock Generator 3
-                      GCLK_GENCTRL_SRC_OSC8M | // Selected source is RC OSC 8MHz (already enabled at reset)
-//                      GCLK_GENCTRL_OE | // Output clock to a pin for tests
-                      GCLK_GENCTRL_GENEN ;
+    while ( GCLK->STATUS.reg & GCLK_STATUS_SYNCBUSY )
+    {
+      /* Wait for synchronization */
+    }
 
-  while ( GCLK->STATUS.reg & GCLK_STATUS_SYNCBUSY )
-  {
-    /* Wait for synchronization */
-  }
+    /* Write Generic Clock Generator 0 configuration */
+    GCLK->GENCTRL.reg = GCLK_GENCTRL_ID( GENERIC_CLOCK_GENERATOR_MAIN ) | // Generic Clock Generator 0
+                        GCLK_GENCTRL_SRC_DFLL48M | // Selected source is DFLL 48MHz
+  //                      GCLK_GENCTRL_OE | // Output clock to a pin for tests
+                        GCLK_GENCTRL_IDC | // Set 50/50 duty cycle
+                        GCLK_GENCTRL_GENEN ;
 
-  /*
-   * Now that all system clocks are configured, we can set CPU and APBx BUS clocks.
-   * There values are normally the one present after Reset.
-   */
-  PM->CPUSEL.reg  = PM_CPUSEL_CPUDIV_DIV1 ;
-  PM->APBASEL.reg = PM_APBASEL_APBADIV_DIV1_Val ;
-  PM->APBBSEL.reg = PM_APBBSEL_APBBDIV_DIV1_Val ;
-  PM->APBCSEL.reg = PM_APBCSEL_APBCDIV_DIV1_Val ;
+    while ( GCLK->STATUS.reg & GCLK_STATUS_SYNCBUSY )
+    {
+      /* Wait for synchronization */
+    }
 
-  SystemCoreClock=VARIANT_MCK ;
+    /* ----------------------------------------------------------------------------------------------
+     * 6) Modify PRESCaler value of OSC8M to have 8MHz
+     */
+    SYSCTRL->OSC8M.bit.PRESC = SYSCTRL_OSC8M_PRESC_0_Val ;  //CMSIS 4.5 changed the prescaler defines
+    SYSCTRL->OSC8M.bit.ONDEMAND = 0 ;
 
-  /* ----------------------------------------------------------------------------------------------
-   * 8) Load ADC factory calibration values
-   */
+    /* ----------------------------------------------------------------------------------------------
+     * 7) Put OSC8M as source for Generic Clock Generator 3
+     */
+    GCLK->GENDIV.reg = GCLK_GENDIV_ID( GENERIC_CLOCK_GENERATOR_OSC8M ) ; // Generic Clock Generator 3
 
-  // ADC Bias Calibration
-  uint32_t bias = (*((uint32_t *) ADC_FUSES_BIASCAL_ADDR) & ADC_FUSES_BIASCAL_Msk) >> ADC_FUSES_BIASCAL_Pos;
+    /* Write Generic Clock Generator 3 configuration */
+    GCLK->GENCTRL.reg = GCLK_GENCTRL_ID( GENERIC_CLOCK_GENERATOR_OSC8M ) | // Generic Clock Generator 3
+                        GCLK_GENCTRL_SRC_OSC8M | // Selected source is RC OSC 8MHz (already enabled at reset)
+  //                      GCLK_GENCTRL_OE | // Output clock to a pin for tests
+                        GCLK_GENCTRL_GENEN ;
 
-  // ADC Linearity bits 4:0
-  uint32_t linearity = (*((uint32_t *) ADC_FUSES_LINEARITY_0_ADDR) & ADC_FUSES_LINEARITY_0_Msk) >> ADC_FUSES_LINEARITY_0_Pos;
+    while ( GCLK->STATUS.reg & GCLK_STATUS_SYNCBUSY )
+    {
+      /* Wait for synchronization */
+    }
 
-  // ADC Linearity bits 7:5
-  linearity |= ((*((uint32_t *) ADC_FUSES_LINEARITY_1_ADDR) & ADC_FUSES_LINEARITY_1_Msk) >> ADC_FUSES_LINEARITY_1_Pos) << 5;
+    /*
+     * Now that all system clocks are configured, we can set CPU and APBx BUS clocks.
+     * There values are normally the one present after Reset.
+     */
+    PM->CPUSEL.reg  = PM_CPUSEL_CPUDIV_DIV1 ;
+    PM->APBASEL.reg = PM_APBASEL_APBADIV_DIV1_Val ;
+    PM->APBBSEL.reg = PM_APBBSEL_APBBDIV_DIV1_Val ;
+    PM->APBCSEL.reg = PM_APBCSEL_APBCDIV_DIV1_Val ;
 
-  ADC->CALIB.reg = ADC_CALIB_BIAS_CAL(bias) | ADC_CALIB_LINEARITY_CAL(linearity);
+    SystemCoreClock=VARIANT_MCK ;
 
-  /*
-   * 9) Disable automatic NVM write operations
-   */
-  NVMCTRL->CTRLB.bit.MANW = 1;
+    /* ----------------------------------------------------------------------------------------------
+     * 8) Load ADC factory calibration values
+     */
+
+    // ADC Bias Calibration
+    uint32_t bias = (*((uint32_t *) ADC_FUSES_BIASCAL_ADDR) & ADC_FUSES_BIASCAL_Msk) >> ADC_FUSES_BIASCAL_Pos;
+
+    // ADC Linearity bits 4:0
+    uint32_t linearity = (*((uint32_t *) ADC_FUSES_LINEARITY_0_ADDR) & ADC_FUSES_LINEARITY_0_Msk) >> ADC_FUSES_LINEARITY_0_Pos;
+
+    // ADC Linearity bits 7:5
+    linearity |= ((*((uint32_t *) ADC_FUSES_LINEARITY_1_ADDR) & ADC_FUSES_LINEARITY_1_Msk) >> ADC_FUSES_LINEARITY_1_Pos) << 5;
+
+    ADC->CALIB.reg = ADC_CALIB_BIAS_CAL(bias) | ADC_CALIB_LINEARITY_CAL(linearity);
+
+    /*
+     * 9) Disable automatic NVM write operations
+     */
+    NVMCTRL->CTRLB.bit.MANW = 1;
   #endif
 }
 

--- a/platform.txt
+++ b/platform.txt
@@ -33,13 +33,13 @@ compiler.warning_flags.all=-Wall -Wextra
 
 compiler.path={runtime.tools.arm-none-eabi-gcc.path}/bin/
 compiler.c.cmd=arm-none-eabi-gcc
-compiler.c.flags=-mcpu={build.mcu} -mthumb -c -g3 -Os {compiler.warning_flags} -std=gnu11 -ffunction-sections -fdata-sections -nostdlib --param max-inline-insns-single=500 -MMD 
+compiler.c.flags=-mcpu={build.mcu} -mthumb -c -g -Os {compiler.warning_flags} -std=gnu11 -ffunction-sections -fdata-sections -nostdlib --param max-inline-insns-single=500 -MMD 
 compiler.c.elf.cmd=arm-none-eabi-gcc
 compiler.c.elf.flags=-Os -Wl,--gc-sections -save-temps
 compiler.S.cmd=arm-none-eabi-gcc
-compiler.S.flags=-c -g3 -x assembler-with-cpp -MMD
+compiler.S.flags=-c -g -x assembler-with-cpp -MMD
 compiler.cpp.cmd=arm-none-eabi-g++
-compiler.cpp.flags=-mcpu={build.mcu} -mthumb -c -g3 -Os {compiler.warning_flags} -std=gnu++11 -ffunction-sections -fdata-sections -fno-threadsafe-statics -nostdlib --param max-inline-insns-single=500 -fno-rtti -fno-exceptions -MMD
+compiler.cpp.flags=-mcpu={build.mcu} -mthumb -c -g -Os {compiler.warning_flags} -std=gnu++11 -ffunction-sections -fdata-sections -fno-threadsafe-statics -nostdlib --param max-inline-insns-single=500 -fno-rtti -fno-exceptions -MMD
 compiler.ar.cmd=arm-none-eabi-ar
 compiler.ar.flags=rcs
 compiler.objcopy.cmd=arm-none-eabi-objcopy


### PR DESCRIPTION
This updates the SAMD21 startup code to match what is currently in arduino samd master branch and fixes the USB/clocking issues on crystalless adafruit SAMD boards.