### PR TITLE
Include unique SAMD51 serial number in USBCore.cpp

### DIFF
--- a/cores/arduino/USB/USBCore.cpp
+++ b/cores/arduino/USB/USBCore.cpp
@@ -245,24 +245,38 @@ bool USBDeviceClass::sendDescriptor(USBSetup &setup)
 		else if (setup.wValueL == ISERIAL) {
 #ifdef PLUGGABLE_USB_ENABLED
 #if defined(__SAMD51__)
-			char name[ISERIAL_MAX_LEN];
-			PluggableUSB().getShortName(name);
-			return sendStringDescriptor((uint8_t*)name, setup.wLength);
+         // char name[ISERIAL_MAX_LEN];
+         // PluggableUSB().getShortName(name);
+         // return sendStringDescriptor((uint8_t*)name, setup.wLength);
+
+         #define SERIAL_NUMBER_WORD_0   *(volatile uint32_t*)(0x008061FC)
+         #define SERIAL_NUMBER_WORD_1   *(volatile uint32_t*)(0x00806010)
+         #define SERIAL_NUMBER_WORD_2   *(volatile uint32_t*)(0x00806014)
+         #define SERIAL_NUMBER_WORD_3   *(volatile uint32_t*)(0x00806018)
+
+         char name[ISERIAL_MAX_LEN];
+         utox8(SERIAL_NUMBER_WORD_0, &name[0]);
+         utox8(SERIAL_NUMBER_WORD_1, &name[8]);
+         utox8(SERIAL_NUMBER_WORD_2, &name[16]);
+         utox8(SERIAL_NUMBER_WORD_3, &name[24]);
+
+         PluggableUSB().getShortName(&name[32]);
+         return sendStringDescriptor((uint8_t*)name, setup.wLength);
 #else
-			// from section 9.3.3 of the datasheet
-			#define SERIAL_NUMBER_WORD_0	*(volatile uint32_t*)(0x0080A00C)
-			#define SERIAL_NUMBER_WORD_1	*(volatile uint32_t*)(0x0080A040)
-			#define SERIAL_NUMBER_WORD_2	*(volatile uint32_t*)(0x0080A044)
-			#define SERIAL_NUMBER_WORD_3	*(volatile uint32_t*)(0x0080A048)
+         // from section 9.3.3 of the datasheet
+         #define SERIAL_NUMBER_WORD_0   *(volatile uint32_t*)(0x0080A00C)
+         #define SERIAL_NUMBER_WORD_1   *(volatile uint32_t*)(0x0080A040)
+         #define SERIAL_NUMBER_WORD_2   *(volatile uint32_t*)(0x0080A044)
+         #define SERIAL_NUMBER_WORD_3   *(volatile uint32_t*)(0x0080A048)
 
-			char name[ISERIAL_MAX_LEN];
-			utox8(SERIAL_NUMBER_WORD_0, &name[0]);
-			utox8(SERIAL_NUMBER_WORD_1, &name[8]);
-			utox8(SERIAL_NUMBER_WORD_2, &name[16]);
-			utox8(SERIAL_NUMBER_WORD_3, &name[24]);
+         char name[ISERIAL_MAX_LEN];
+         utox8(SERIAL_NUMBER_WORD_0, &name[0]);
+         utox8(SERIAL_NUMBER_WORD_1, &name[8]);
+         utox8(SERIAL_NUMBER_WORD_2, &name[16]);
+         utox8(SERIAL_NUMBER_WORD_3, &name[24]);
 
-			PluggableUSB().getShortName(&name[32]);
-			return sendStringDescriptor((uint8_t*)name, setup.wLength);
+         PluggableUSB().getShortName(&name[32]);
+         return sendStringDescriptor((uint8_t*)name, setup.wLength);
 #endif
 #endif
 		}


### PR DESCRIPTION
This is useful when multiple boards are plugged in and you need to keep them properly identified. Using same approach as SAMD21 but with SAMD51 device-specific addresses.