### PR TITLE
Update wiring_analog.c and wiring_analog.h

### DIFF
--- a/cores/arduino/wiring_analog.c
+++ b/cores/arduino/wiring_analog.c
@@ -150,7 +150,7 @@ void analogReference(eAnalogReference mode)
 		
 		case AR_INTERNAL1V1:
 		//ADC0->GAINCORR.reg = ADC_GAINCORR_GAINCORR();      // Gain Factor Selection
-		SUPC->VREF.bit.SEL = SUPC_VREF_SEL_1V1_Val;		// select 1.0V
+		SUPC->VREF.bit.SEL = SUPC_VREF_SEL_1V1_Val;		// select 1.1V
 		SUPC->VREF.bit.VREFOE = 1;	//	Turn on for use with ADC
 		ADC0->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_INTREF_Val; // Use SUPC.VREF
 		ADC1->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_INTREF_Val; // 
@@ -158,7 +158,7 @@ void analogReference(eAnalogReference mode)
 		
 		case AR_INTERNAL1V2:
 		//ADC0->GAINCORR.reg = ADC_GAINCORR_GAINCORR();      // Gain Factor Selection
-		SUPC->VREF.bit.SEL = SUPC_VREF_SEL_1V2_Val;		// select 1.0V
+		SUPC->VREF.bit.SEL = SUPC_VREF_SEL_1V2_Val;		// select 1V2
 		SUPC->VREF.bit.VREFOE = 1;	//	Turn on for use with ADC
 		ADC0->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_INTREF_Val; // Use SUPC.VREF
 		ADC1->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_INTREF_Val; // 
@@ -166,7 +166,7 @@ void analogReference(eAnalogReference mode)
 
 		case AR_INTERNAL1V25:
 		//ADC0->GAINCORR.reg = ADC_GAINCORR_GAINCORR();      // Gain Factor Selection
-		SUPC->VREF.bit.SEL = SUPC_VREF_SEL_1V25_Val;		// select 1.0V
+		SUPC->VREF.bit.SEL = SUPC_VREF_SEL_1V25_Val;		// select 1.25V
 		SUPC->VREF.bit.VREFOE = 1;	//	Turn on for use with ADC
 		ADC0->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_INTREF_Val; // Use SUPC.VREF
 		ADC1->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_INTREF_Val; // 
@@ -174,7 +174,7 @@ void analogReference(eAnalogReference mode)
 		
 		case AR_INTERNAL2V0:
 		//ADC0->GAINCORR.reg = ADC_GAINCORR_GAINCORR();      // Gain Factor Selection
-		SUPC->VREF.bit.SEL = SUPC_VREF_SEL_2V0_Val;		// select 1.0V
+		SUPC->VREF.bit.SEL = SUPC_VREF_SEL_2V0_Val;		// select 2.0V
 		SUPC->VREF.bit.VREFOE = 1;	//	Turn on for use with ADC
 		ADC0->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_INTREF_Val; // Use SUPC.VREF
 		ADC1->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_INTREF_Val; // 
@@ -182,7 +182,7 @@ void analogReference(eAnalogReference mode)
 		
 		case AR_INTERNAL2V2:
 		//ADC0->GAINCORR.reg = ADC_GAINCORR_GAINCORR();      // Gain Factor Selection
-		SUPC->VREF.bit.SEL = SUPC_VREF_SEL_2V2_Val;		// select 1.0V
+		SUPC->VREF.bit.SEL = SUPC_VREF_SEL_2V2_Val;		// select 2.2V
 		SUPC->VREF.bit.VREFOE = 1;	//	Turn on for use with ADC
 		ADC0->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_INTREF_Val; // Use SUPC.VREF
 		ADC1->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_INTREF_Val; // 
@@ -190,7 +190,7 @@ void analogReference(eAnalogReference mode)
 		
 		case AR_INTERNAL2V4:
 		//ADC0->GAINCORR.reg = ADC_GAINCORR_GAINCORR();      // Gain Factor Selection
-		SUPC->VREF.bit.SEL = SUPC_VREF_SEL_2V4_Val;		// select 1.0V
+		SUPC->VREF.bit.SEL = SUPC_VREF_SEL_2V4_Val;		// select 2.4V
 		SUPC->VREF.bit.VREFOE = 1;	//	Turn on for use with ADC
 		ADC0->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_INTREF_Val; // Use SUPC.VREF
 		ADC1->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_INTREF_Val; // 
@@ -198,7 +198,7 @@ void analogReference(eAnalogReference mode)
 		
 		case AR_INTERNAL2V5:
 		//ADC0->GAINCORR.reg = ADC_GAINCORR_GAINCORR();      // Gain Factor Selection
-		SUPC->VREF.bit.SEL = SUPC_VREF_SEL_2V5_Val;		// select 1.0V
+		SUPC->VREF.bit.SEL = SUPC_VREF_SEL_2V5_Val;		// select 2.5V
 		SUPC->VREF.bit.VREFOE = 1;	//	Turn on for use with ADC
 		ADC0->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_INTREF_Val; // Use SUPC.VREF
 		ADC1->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_INTREF_Val; // 
@@ -206,7 +206,7 @@ void analogReference(eAnalogReference mode)
 		
 		case AR_EXTERNAL:
 		//ADC0->INPUTCTRL.bit.GAIN = ADC_INPUTCTRL_GAIN_1X_Val;      // Gain Factor Selection
-		ADC0->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_AREFA_Val;
+		ADC0->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_AREFA_Val;	// AREF is jumpered to VCC, so 3.3V
 		ADC1->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_AREFA_Val;
 		break;
 

--- a/cores/arduino/wiring_analog.c
+++ b/cores/arduino/wiring_analog.c
@@ -140,38 +140,87 @@ void analogReference(eAnalogReference mode)
 	//TODO: fix gains
 	switch (mode)
 	{
-		case AR_INTERNAL:
-		case AR_INTERNAL2V23:
+		case AR_INTERNAL1V0:
 		//ADC0->GAINCORR.reg = ADC_GAINCORR_GAINCORR();      // Gain Factor Selection
-		ADC0->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_INTVCC0_Val; // 1/1.48 VDDANA = 1/1.48* 3V3 = 2.2297
-		ADC1->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_INTVCC0_Val; // 1/1.48 VDDANA = 1/1.48* 3V3 = 2.2297
+		SUPC->VREF.bit.SEL = SUPC_VREF_SEL_1V0_Val;		// select 1.0V
+		SUPC->VREF.bit.VREFOE = 1;	//	Turn on for use with ADC
+		ADC0->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_INTREF_Val; // Use SUPC.VREF
+		ADC1->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_INTREF_Val; // 
+		break;
+		
+		case AR_INTERNAL1V1:
+		//ADC0->GAINCORR.reg = ADC_GAINCORR_GAINCORR();      // Gain Factor Selection
+		SUPC->VREF.bit.SEL = SUPC_VREF_SEL_1V1_Val;		// select 1.0V
+		SUPC->VREF.bit.VREFOE = 1;	//	Turn on for use with ADC
+		ADC0->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_INTREF_Val; // Use SUPC.VREF
+		ADC1->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_INTREF_Val; // 
+		break;
+		
+		case AR_INTERNAL1V2:
+		//ADC0->GAINCORR.reg = ADC_GAINCORR_GAINCORR();      // Gain Factor Selection
+		SUPC->VREF.bit.SEL = SUPC_VREF_SEL_1V2_Val;		// select 1.0V
+		SUPC->VREF.bit.VREFOE = 1;	//	Turn on for use with ADC
+		ADC0->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_INTREF_Val; // Use SUPC.VREF
+		ADC1->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_INTREF_Val; // 
 		break;
 
+		case AR_INTERNAL1V25:
+		//ADC0->GAINCORR.reg = ADC_GAINCORR_GAINCORR();      // Gain Factor Selection
+		SUPC->VREF.bit.SEL = SUPC_VREF_SEL_1V25_Val;		// select 1.0V
+		SUPC->VREF.bit.VREFOE = 1;	//	Turn on for use with ADC
+		ADC0->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_INTREF_Val; // Use SUPC.VREF
+		ADC1->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_INTREF_Val; // 
+		break;
+		
+		case AR_INTERNAL2V0:
+		//ADC0->GAINCORR.reg = ADC_GAINCORR_GAINCORR();      // Gain Factor Selection
+		SUPC->VREF.bit.SEL = SUPC_VREF_SEL_2V0_Val;		// select 1.0V
+		SUPC->VREF.bit.VREFOE = 1;	//	Turn on for use with ADC
+		ADC0->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_INTREF_Val; // Use SUPC.VREF
+		ADC1->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_INTREF_Val; // 
+		break;
+		
+		case AR_INTERNAL2V2:
+		//ADC0->GAINCORR.reg = ADC_GAINCORR_GAINCORR();      // Gain Factor Selection
+		SUPC->VREF.bit.SEL = SUPC_VREF_SEL_2V2_Val;		// select 1.0V
+		SUPC->VREF.bit.VREFOE = 1;	//	Turn on for use with ADC
+		ADC0->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_INTREF_Val; // Use SUPC.VREF
+		ADC1->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_INTREF_Val; // 
+		break;
+		
+		case AR_INTERNAL2V4:
+		//ADC0->GAINCORR.reg = ADC_GAINCORR_GAINCORR();      // Gain Factor Selection
+		SUPC->VREF.bit.SEL = SUPC_VREF_SEL_2V4_Val;		// select 1.0V
+		SUPC->VREF.bit.VREFOE = 1;	//	Turn on for use with ADC
+		ADC0->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_INTREF_Val; // Use SUPC.VREF
+		ADC1->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_INTREF_Val; // 
+		break;
+		
+		case AR_INTERNAL2V5:
+		//ADC0->GAINCORR.reg = ADC_GAINCORR_GAINCORR();      // Gain Factor Selection
+		SUPC->VREF.bit.SEL = SUPC_VREF_SEL_2V5_Val;		// select 1.0V
+		SUPC->VREF.bit.VREFOE = 1;	//	Turn on for use with ADC
+		ADC0->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_INTREF_Val; // Use SUPC.VREF
+		ADC1->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_INTREF_Val; // 
+		break;
+		
 		case AR_EXTERNAL:
 		//ADC0->INPUTCTRL.bit.GAIN = ADC_INPUTCTRL_GAIN_1X_Val;      // Gain Factor Selection
 		ADC0->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_AREFA_Val;
 		ADC1->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_AREFA_Val;
 		break;
 
-/*		Don't think this works on SAMD51
-		case AR_INTERNAL1V0:
-		//ADC0->INPUTCTRL.bit.GAIN = ADC_INPUTCTRL_GAIN_1X_Val;      // Gain Factor Selection
-		ADC0->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_INT1V_Val;   // 1.0V voltage reference
-		break;
-*/
-
 		case AR_INTERNAL1V65:
-		//ADC0->INPUTCTRL.bit.GAIN = ADC_INPUTCTRL_GAIN_1X_Val;      // Gain Factor Selection
-		ADC0->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_INTVCC1_Val; // 1/2 VDDANA = 0.5* 3V3 = 1.65V
-		ADC1->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_INTVCC1_Val; // 1/2 VDDANA = 0.5* 3V3 = 1.65V
+		//ADC0->INPUTCTRL.bit.GAIN = ADC_INPUTCTRL_GAIN_DIV2_Val;
+		ADC0->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_INTVCC0_Val; // 1/2 VDDANA = 1.65
+		ADC1->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_INTVCC0_Val; // 
 		break;
-
+		
 		case AR_DEFAULT:
 		default:
 		//ADC0->INPUTCTRL.bit.GAIN = ADC_INPUTCTRL_GAIN_DIV2_Val;
-		ADC0->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_INTVCC1_Val; // 1/2 VDDANA = 0.5* 3V3 = 1.65V
-		ADC1->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_INTVCC1_Val; // 1/2 VDDANA = 0.5* 3V3 = 1.65V
-		
+		ADC0->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_INTVCC1_Val; // VDDANA = 3V3
+		ADC1->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_INTVCC1_Val; // 
 		break;
 	}
 	

--- a/cores/arduino/wiring_analog.h
+++ b/cores/arduino/wiring_analog.h
@@ -27,14 +27,20 @@ extern "C" {
 /*
  * \brief SAMD products have only one reference for ADC
  */
+ // add internal voltages for ATSAMD51 SUPC VREF register
 typedef enum _eAnalogReference
 {
   AR_DEFAULT,
-  AR_INTERNAL,
-  AR_EXTERNAL,
   AR_INTERNAL1V0,
+  AR_INTERNAL1V1,
+  AR_INTERNAL1V2,
+  AR_INTERNAL1V25,
+  AR_INTERNAL2V0,
+  AR_INTERNAL2V2,
+  AR_INTERNAL2V4,
+  AR_INTERNAL2V5,
   AR_INTERNAL1V65,
-  AR_INTERNAL2V23
+  AR_EXTERNAL
 } eAnalogReference ;
 
 


### PR DESCRIPTION
Update analogReference() function in wiring_analog.c and .h to correct voltages and make use of internal bandgap reference using SUPC.VREF register settings.  Reference my post in forum: [Link to forum post](https://forums.adafruit.com/viewtopic.php?f=57&t=145588)

I tried this earlier but I am new with GitHub process.  I think I did it correctly this time.