### PR TITLE
Fix delayMicroseconds() on SAMD51

### DIFF
--- a/cores/arduino/delay.h
+++ b/cores/arduino/delay.h
@@ -61,6 +61,9 @@ extern void delay( unsigned long dwMs ) ;
  *
  * \param dwUs the number of microseconds to pause (uint32_t)
  */
+#if defined(__SAMD51__)
+extern void delayMicroseconds( unsigned int );
+#else
 static __inline__ void delayMicroseconds( unsigned int ) __attribute__((always_inline, unused)) ;
 static __inline__ void delayMicroseconds( unsigned int usec )
 {
@@ -68,21 +71,6 @@ static __inline__ void delayMicroseconds( unsigned int usec )
   {
     return ;
   }
-
-#if defined(__SAMD51__)
-  uint32_t n = usec * (VARIANT_MCK / 1000000) / 12;
-
-  __asm__ __volatile__(
-    "1:              \n"
-    "   sub %0, #1   \n" // substract 1 from %0 (n)
-    "   cmp %0, #0   \n" // compare to 0
-    "   bne 1b       \n" // if result is not 0 jump to 1
-    : "+r" (n)           // '%0' is n variable with RW constraints
-    :                    // no input
-    :                    // no clobber
-  );
-
-#else
   /*
    *  The following loop:
    *
@@ -109,10 +97,10 @@ static __inline__ void delayMicroseconds( unsigned int usec )
     :                    // no input
     :                    // no clobber
   );
-#endif
   // https://gcc.gnu.org/onlinedocs/gcc/Extended-Asm.html
   // https://gcc.gnu.org/onlinedocs/gcc/Extended-Asm.html#Volatile
 }
+#endif
 
 #ifdef __cplusplus
 }

--- a/cores/arduino/startup.c
+++ b/cores/arduino/startup.c
@@ -252,7 +252,14 @@ void SystemInit( void )
   CMCC->CTRL.reg = 1;
   __enable_irq();
 #endif
-  
+
+  /*---------------------------------------------------------------------
+   * Start up the "Debug Watchpoint and Trace" unit, so that we can use
+   * it's 32bit cycle counter for timing.
+   */
+  CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
+  DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;
+
 //*************** END SAMD51 *************************//
   
 #else


### PR DESCRIPTION
https://github.com/adafruit/ArduinoCore-samd/issues/71

Enable and use the 32bit cycle counter in the CM4 DWT hardware.
Tested over a range of arguments from 1 to 2000us; quite accurate!
