### PR TITLE
Fix 'Unused Parameter' warnings in HardwareSerial.h

### DIFF
--- a/cores/arduino/HardwareSerial.h
+++ b/cores/arduino/HardwareSerial.h
@@ -68,7 +68,7 @@ class HardwareSerial : public Stream
 {
   public:
     virtual void begin(unsigned long) {}
-    virtual void begin(unsigned long baudrate, uint16_t config) {}
+    virtual void begin(unsigned long, uint16_t) {}
     virtual void end() {}
     virtual int available(void) = 0;
     virtual int peek(void) = 0;


### PR DESCRIPTION
This small change removes many of the warnings that are generated when compiling this core with warnings switched on.

Since HardwareSerial is referenced a lot during build, the fact that baudrate and config are not used in the empty function body generates a massive amount of warnings. This PR fixes that.