### PR TITLE
Fix Feather M4 I2S pins

### DIFF
--- a/variants/feather_m4/variant.h
+++ b/variants/feather_m4/variant.h
@@ -175,10 +175,11 @@ static const uint8_t SCL = PIN_WIRE_SCL;
 #define I2S_DEVICE          0
 #define I2S_CLOCK_GENERATOR 3
 
-#define PIN_I2S_SDO          (5u)
-#define PIN_I2S_SDI          PIN_SPI_MOSI
-#define PIN_I2S_SCK          PIN_A2
-#define PIN_I2S_FS           PIN_SPI_MISO
+#define PIN_I2S_SDO          (11u)
+#define PIN_I2S_SDI          (12u)
+#define PIN_I2S_SCK          PIN_SERIAL1_TX
+#define PIN_I2S_FS           (10u)
+#define PIN_I2S_MCK          PIN_SERIAL1_RX
 
 //QSPI Pins
 #define PIN_QSPI_SCK    (34u)


### PR DESCRIPTION
Tested with this example: 
https://github.com/adafruit/Adafruit_ZeroI2S/blob/master/examples/basic/basic.ino
but using default pins:
```cpp
//Adafruit_ZeroI2S i2s(0, 1, 9, 2);
Adafruit_ZeroI2S i2s;
```
it made noise:
![feather_m4_i2s_test](https://user-images.githubusercontent.com/8755041/51502782-79f16180-1d8c-11e9-89f8-e1a40c4dc85e.jpg)

