### PR TITLE
Do not initialize all pins to INPUT

### DIFF
--- a/cores/arduino/wiring.c
+++ b/cores/arduino/wiring.c
@@ -102,11 +102,16 @@ void init( void )
   #endif
 #endif
 
+/* 
+  Commented out to leave pins in default tri-state.  This is
+  aimed at avoiding power consumption in DeepSleep.
+  
   // Setup all pins (digital and analog) in INPUT mode (default is nothing)
   for (uint32_t ul = 0 ; ul < NUM_DIGITAL_PINS ; ul++ )
   {
     pinMode( ul, INPUT ) ;
   }
+*/
 
   // Initialize Analog Controller
   // Setting clock


### PR DESCRIPTION
Comment out the initialization of all SAMD21 pins to INPUT to allow them to remain tri-stated by default.   

See https://github.com/adafruit/Adafruit_SleepyDog/issues/17#issuecomment-481798215