### PR TITLE
fix tinyusb bug with clear stall and reset data toggle 

### DIFF
--- a/cores/arduino/Adafruit_TinyUSB_Core/Adafruit_TinyUSB_Core.cpp
+++ b/cores/arduino/Adafruit_TinyUSB_Core/Adafruit_TinyUSB_Core.cpp
@@ -22,7 +22,7 @@
  * THE SOFTWARE.
  */
 
-#if defined(USE_TINYUSB) && defined(USBCON)
+#ifdef USE_TINYUSB
 
 #include "Arduino.h"
 #include "Adafruit_TinyUSB_Core.h"
@@ -128,4 +128,4 @@ void Adafruit_TinyUSB_Core_init(void)
   tusb_init();
 }
 
-#endif
+#endif // USE_TINYUSB

--- a/cores/arduino/Adafruit_TinyUSB_Core/Adafruit_TinyUSB_Core.h
+++ b/cores/arduino/Adafruit_TinyUSB_Core/Adafruit_TinyUSB_Core.h
@@ -25,6 +25,10 @@
 #ifndef ADAFRUIT_TINYUSB_CORE_H_
 #define ADAFRUIT_TINYUSB_CORE_H_
 
+#ifndef USE_TINYUSB
+#error TinyUSB is not selected, please select it in Tools->Menu->USB Stack
+#endif
+
 #include "tusb.h"
 
 #ifdef __cplusplus

--- a/cores/arduino/Adafruit_TinyUSB_Core/Adafruit_USBD_CDC.cpp
+++ b/cores/arduino/Adafruit_TinyUSB_Core/Adafruit_USBD_CDC.cpp
@@ -22,7 +22,7 @@
  * THE SOFTWARE.
  */
 
-#if defined(USE_TINYUSB) && defined(USBCON)
+#ifdef USE_TINYUSB
 
 #include "Arduino.h"
 #include <Reset.h> // Needed for auto-reset with 1200bps port touch
@@ -139,4 +139,4 @@ void tud_cdc_line_state_cb(uint8_t itf, bool dtr, bool rts)
 
 }
 
-#endif // NRF52840_XXAA
+#endif // USE_TINYUSB

--- a/cores/arduino/Adafruit_TinyUSB_Core/Adafruit_USBD_Device.cpp
+++ b/cores/arduino/Adafruit_TinyUSB_Core/Adafruit_USBD_Device.cpp
@@ -22,7 +22,7 @@
  * THE SOFTWARE.
  */
 
-#if defined(USE_TINYUSB) && defined(USBCON)
+#ifdef USE_TINYUSB
 
 #include "Adafruit_USBD_Device.h"
 
@@ -184,4 +184,4 @@ bool Adafruit_USBD_Device::begin(void)
   return true;
 }
 
-#endif
+#endif // USE_TINYUSB

--- a/cores/arduino/Adafruit_TinyUSB_Core/tinyusb/src/class/msc/msc_device.h
+++ b/cores/arduino/Adafruit_TinyUSB_Core/tinyusb/src/class/msc/msc_device.h
@@ -44,18 +44,6 @@ TU_VERIFY_STATIC(CFG_TUD_MSC_BUFSIZE < UINT16_MAX, "Size is not correct");
   #error CFG_TUD_MSC_BUFSIZE must be defined, value of a block size should work well, the more the better
 #endif
 
-#ifndef CFG_TUD_MSC_VENDOR
-  #error CFG_TUD_MSC_VENDOR 8-byte name must be defined
-#endif
-
-#ifndef CFG_TUD_MSC_PRODUCT
-  #error CFG_TUD_MSC_PRODUCT 16-byte name must be defined
-#endif
-
-#ifndef CFG_TUD_MSC_PRODUCT_REV
-  #error CFG_TUD_MSC_PRODUCT_REV 4-byte string must be defined
-#endif
-
 /** \addtogroup ClassDriver_MSC
  *  @{
  * \defgroup MSC_Device Device
@@ -105,12 +93,23 @@ ATTR_WEAK int32_t tud_msc_read10_cb (uint8_t lun, uint32_t lba, uint32_t offset,
  */
 ATTR_WEAK int32_t tud_msc_write10_cb (uint8_t lun, uint32_t lba, uint32_t offset, uint8_t* buffer, uint32_t bufsize);
 
+// Invoked when received SCSI_CMD_INQUIRY
+// Application fill vendor id, product id and revision with string up to 8, 16, 4 characters respectively
+ATTR_WEAK void tud_msc_inquiry_cb(uint8_t lun, uint8_t vendor_id[8], uint8_t product_id[16], uint8_t product_rev[4]);
+
+// Invoked when received Test Unit Ready command.
+// return true allowing host to read/write this LUN e.g SD card inserted
+ATTR_WEAK bool tud_msc_test_unit_ready_cb(uint8_t lun);
+
 // Invoked when received SCSI_CMD_READ_CAPACITY_10 and SCSI_CMD_READ_FORMAT_CAPACITY to determine the disk size
 // Application update block count and block size
 ATTR_WEAK void tud_msc_capacity_cb(uint8_t lun, uint32_t* block_count, uint16_t* block_size);
 
 /**
- * Callback invoked when received an SCSI command not in built-in list below.
+ * Invoked when received an SCSI command not in built-in list below.
+ * - READ_CAPACITY10, READ_FORMAT_CAPACITY, INQUIRY, TEST_UNIT_READY, PREVENT_ALLOW_MEDIUM_REMOVE, MODE_SENSE6, REQUEST_SENSE
+ * - READ10 and WRITE10 has their own callbacks
+ *
  * \param[in]   lun         Logical unit number
  * \param[in]   scsi_cmd    SCSI command contents which application must examine to response accordingly
  * \param[out]  buffer      Buffer for SCSI Data Stage.
@@ -121,17 +120,18 @@ ATTR_WEAK void tud_msc_capacity_cb(uint8_t lun, uint32_t* block_count, uint16_t*
  * \return      Actual bytes processed, can be zero for no-data command.
  * \retval      negative    Indicate error e.g unsupported command, tinyusb will \b STALL the corresponding
  *                          endpoint and return failed status in command status wrapper phase.
- *
- * \note        Following command is automatically handled by tinyusb stack, callback should not be worried:
- *              - READ_CAPACITY10, READ_FORMAT_CAPACITY, INQUIRY, MODE_SENSE6, REQUEST_SENSE
- *              - READ10 and WRITE10 has their own callbacks
  */
 ATTR_WEAK int32_t tud_msc_scsi_cb (uint8_t lun, uint8_t const scsi_cmd[16], void* buffer, uint16_t bufsize);
 
 /*------------- Optional callbacks -------------*/
 
-// Invoked when received GET_MAX_LUN request
-ATTR_WEAK uint8_t tud_msc_maxlun_cb(void);
+// Invoked when received GET_MAX_LUN request, required for multiple LUNs implementation
+ATTR_WEAK uint8_t tud_msc_get_maxlun_cb(void);
+
+// Invoked when received Start Stop Unit command
+// - Start = 0 : stopped power mode, if load_eject = 1 : unload disk storage
+// - Start = 1 : active mode, if load_eject = 1 : load disk storage
+ATTR_WEAK void tud_msc_start_stop_cb(uint8_t lun, uint8_t power_condition, bool start, bool load_eject);
 
 // Invoked when Read10 command is complete
 ATTR_WEAK void tud_msc_read10_complete_cb(uint8_t lun);

--- a/cores/arduino/Adafruit_TinyUSB_Core/tinyusb/src/device/dcd.h
+++ b/cores/arduino/Adafruit_TinyUSB_Core/tinyusb/src/device/dcd.h
@@ -107,7 +107,7 @@ void dcd_remote_wakeup(uint8_t rhport);
  *                  must be called to notify the stack
  *  - busy        : Check if endpoint transferring is complete (TODO remove)
  *  - stall       : stall endpoint
- *  - clear_stall : clear stall
+ *  - clear_stall : clear stall, data toggle is also reset to DATA0
  *------------------------------------------------------------------*/
 bool dcd_edpt_open        (uint8_t rhport, tusb_desc_endpoint_t const * p_endpoint_desc);
 bool dcd_edpt_xfer        (uint8_t rhport, uint8_t ep_addr, uint8_t * buffer, uint16_t total_bytes);

--- a/cores/arduino/Adafruit_TinyUSB_Core/tinyusb/src/device/usbd.c
+++ b/cores/arduino/Adafruit_TinyUSB_Core/tinyusb/src/device/usbd.c
@@ -456,7 +456,7 @@ static bool process_control_request(uint8_t rhport, tusb_control_request_t const
         case TUSB_REQ_CLEAR_FEATURE:
           if ( TUSB_REQ_FEATURE_EDPT_HALT == p_request->wValue )
           {
-            dcd_edpt_clear_stall(rhport, tu_u16_low(p_request->wIndex));
+            usbd_edpt_clear_stall(rhport, tu_u16_low(p_request->wIndex));
           }
           usbd_control_status(rhport, p_request);
         break;

--- a/cores/arduino/Adafruit_TinyUSB_Core/tinyusb/src/portable/microchip/samd21/dcd_samd21.c
+++ b/cores/arduino/Adafruit_TinyUSB_Core/tinyusb/src/portable/microchip/samd21/dcd_samd21.c
@@ -223,9 +223,9 @@ void dcd_edpt_clear_stall (uint8_t rhport, uint8_t ep_addr)
   UsbDeviceEndpoint* ep = &USB->DEVICE.DeviceEndpoint[epnum];
 
   if (tu_edpt_dir(ep_addr) == TUSB_DIR_IN) {
-    ep->EPSTATUSCLR.reg = USB_DEVICE_EPSTATUSCLR_STALLRQ1;
+    ep->EPSTATUSCLR.reg = USB_DEVICE_EPSTATUSCLR_STALLRQ1 | USB_DEVICE_EPSTATUSCLR_DTGLIN;
   } else {
-    ep->EPSTATUSCLR.reg = USB_DEVICE_EPSTATUSCLR_STALLRQ0;
+    ep->EPSTATUSCLR.reg = USB_DEVICE_EPSTATUSCLR_STALLRQ0 | USB_DEVICE_EPSTATUSCLR_DTGLOUT;
   }
 }
 

--- a/cores/arduino/Adafruit_TinyUSB_Core/tinyusb/src/portable/microchip/samd51/dcd_samd51.c
+++ b/cores/arduino/Adafruit_TinyUSB_Core/tinyusb/src/portable/microchip/samd51/dcd_samd51.c
@@ -227,9 +227,9 @@ void dcd_edpt_clear_stall (uint8_t rhport, uint8_t ep_addr)
   UsbDeviceEndpoint* ep = &USB->DEVICE.DeviceEndpoint[epnum];
 
   if (tu_edpt_dir(ep_addr) == TUSB_DIR_IN) {
-    ep->EPSTATUSCLR.reg = USB_DEVICE_EPSTATUSCLR_STALLRQ1;
+    ep->EPSTATUSCLR.reg = USB_DEVICE_EPSTATUSCLR_STALLRQ1 | USB_DEVICE_EPSTATUSCLR_DTGLIN;
   } else {
-    ep->EPSTATUSCLR.reg = USB_DEVICE_EPSTATUSCLR_STALLRQ0;
+    ep->EPSTATUSCLR.reg = USB_DEVICE_EPSTATUSCLR_STALLRQ0 | USB_DEVICE_EPSTATUSCLR_DTGLOUT;
   }
 }
 

--- a/cores/arduino/Adafruit_TinyUSB_Core/tinyusb/src/tusb_option.h
+++ b/cores/arduino/Adafruit_TinyUSB_Core/tinyusb/src/tusb_option.h
@@ -128,7 +128,6 @@
 */
 #ifndef CFG_TUSB_DEBUG
   #define CFG_TUSB_DEBUG 0
-  #warning CFG_TUSB_DEBUG is not defined, default value is 0
 #endif
 
 // place data in accessible RAM for usb controller
@@ -163,6 +162,15 @@
 
   #ifndef CFG_TUD_MSC
     #define CFG_TUD_MSC          0
+  #endif
+
+
+  #ifndef CFG_TUD_MIDI
+    #define CFG_TUD_MIDI            0
+  #endif
+
+  #ifndef CFG_TUD_CUSTOM_CLASS
+    #define CFG_TUD_CUSTOM_CLASS    0
   #endif
 
 #endif // TUSB_OPT_DEVICE_ENABLED

--- a/cores/arduino/Adafruit_TinyUSB_Core/tusb_config.h
+++ b/cores/arduino/Adafruit_TinyUSB_Core/tusb_config.h
@@ -45,7 +45,6 @@
 #endif
 
 #define CFG_TUSB_OS                 OPT_OS_NONE
-#define CFG_TUSB_DEBUG              0
 
 #define CFG_TUSB_MEM_SECTION
 #define CFG_TUSB_MEM_ALIGN          ATTR_ALIGNED(4)
@@ -75,19 +74,11 @@
 // Buffer size of Device Mass storage
 #define CFG_TUD_MSC_BUFSIZE         512
 
-// Vendor name included in Inquiry response, max 8 bytes
-#define CFG_TUD_MSC_VENDOR          "Adafruit"
-
-// Product name included in Inquiry response, max 16 bytes
-#define CFG_TUD_MSC_PRODUCT         "Bluefruit nRF52"
-
-// Product revision string included in Inquiry response, max 4 bytes
-#define CFG_TUD_MSC_PRODUCT_REV     "1.0"
-
 //------------- HID -------------//
 
 // Should be sufficient to hold ID (if any) + Data
 #define CFG_TUD_HID_BUFSIZE         64
+
 
 #ifdef __cplusplus
  }

--- a/cores/arduino/main.cpp
+++ b/cores/arduino/main.cpp
@@ -40,13 +40,11 @@ int main( void )
 
   delay(1);
 
-#if defined(USBCON)
- #if defined(USE_TINYUSB)
+#if defined(USE_TINYUSB)
   Adafruit_TinyUSB_Core_init();
- #else
+#elif defined(USBCON)
   USBDevice.init();
   USBDevice.attach();
- #endif
 #endif
 
   setup();
@@ -55,7 +53,7 @@ int main( void )
   {
     loop();
 
-#if defined(USE_TINYUSB) && defined(USBCON)
+#ifdef USE_TINYUSB
     tud_task();
 #endif
 
@@ -65,7 +63,7 @@ int main( void )
   return 0;
 }
 
-#if defined(USE_TINYUSB) && defined(USBCON)
+#ifdef USE_TINYUSB
 void yield(void)
 {
   tud_task();


### PR DESCRIPTION
@ladyada  this PR will allow samd to run with `sdcard_reader`

https://github.com/adafruit/Adafruit_TinyUSB_Arduino/blob/master/examples/sdcard_reader/sdcard_reader.ino

sdcard_reader run with both nrf52 and samd, but the speed is awful now. You need to wait for several minutes before the SD contents show up. PC try to read a several MB from the SD card first before showing it up ( I tested with a 2 GB card). I will try to see if I could tune up anything to speed it up later