### PR TITLE
Better SPI SERCOM clock control

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -17,7 +17,6 @@
 menu.cache=Cache
 menu.speed=CPU Speed
 menu.opt=Optimize
-menu.maxspi=Max SPI
 menu.maxqspi=Max QSPI
 
 # Adafruit Feather M0 (SAMD21)
@@ -337,12 +336,6 @@ adafruit_metro_m4.menu.opt.fast=Fast (-O2)
 adafruit_metro_m4.menu.opt.fast.build.flags.optimize=-O2
 adafruit_metro_m4.menu.opt.dragons=Here be dragons (-Ofast -funroll-loops)
 adafruit_metro_m4.menu.opt.dragons.build.flags.optimize=-Ofast -funroll-loops
-adafruit_metro_m4.menu.maxspi.24=24 MHz (standard)
-adafruit_metro_m4.menu.maxspi.24.build.flags.maxspi=-DMAX_SPI=24000000
-adafruit_metro_m4.menu.maxspi.50=50 MHz
-adafruit_metro_m4.menu.maxspi.50.build.flags.maxspi=-DMAX_SPI=50000000
-adafruit_metro_m4.menu.maxspi.fcpu2=CPU Speed / 2
-adafruit_metro_m4.menu.maxspi.fcpu2.build.flags.maxspi=-DMAX_SPI=({build.f_cpu}/2)
 adafruit_metro_m4.menu.maxqspi.50=50 MHz (standard)
 adafruit_metro_m4.menu.maxqspi.50.build.flags.maxqspi=-DVARIANT_QSPI_BAUD_DEFAULT=50000000
 adafruit_metro_m4.menu.maxqspi.fcpu=CPU Speed / 2
@@ -396,12 +389,6 @@ adafruit_grandcentral_m4.menu.opt.fast=Fast (-O2)
 adafruit_grandcentral_m4.menu.opt.fast.build.flags.optimize=-O2
 adafruit_grandcentral_m4.menu.opt.dragons=Here be dragons (-Ofast -funroll-loops)
 adafruit_grandcentral_m4.menu.opt.dragons.build.flags.optimize=-Ofast -funroll-loops
-adafruit_grandcentral_m4.menu.maxspi.24=24 MHz (standard)
-adafruit_grandcentral_m4.menu.maxspi.24.build.flags.maxspi=-DMAX_SPI=24000000
-adafruit_grandcentral_m4.menu.maxspi.50=50 MHz
-adafruit_grandcentral_m4.menu.maxspi.50.build.flags.maxspi=-DMAX_SPI=50000000
-adafruit_grandcentral_m4.menu.maxspi.fcpu2=CPU Speed / 2
-adafruit_grandcentral_m4.menu.maxspi.fcpu2.build.flags.maxspi=-DMAX_SPI=({build.f_cpu}/2)
 adafruit_grandcentral_m4.menu.maxqspi.50=50 MHz (standard)
 adafruit_grandcentral_m4.menu.maxqspi.50.build.flags.maxqspi=-DVARIANT_QSPI_BAUD_DEFAULT=50000000
 adafruit_grandcentral_m4.menu.maxqspi.fcpu=CPU Speed / 2
@@ -455,12 +442,6 @@ adafruit_itsybitsy_m4.menu.opt.fast=Fast (-O2)
 adafruit_itsybitsy_m4.menu.opt.fast.build.flags.optimize=-O2
 adafruit_itsybitsy_m4.menu.opt.dragons=Here be dragons (-Ofast -funroll-loops)
 adafruit_itsybitsy_m4.menu.opt.dragons.build.flags.optimize=-Ofast -funroll-loops
-adafruit_itsybitsy_m4.menu.maxspi.24=24 MHz (standard)
-adafruit_itsybitsy_m4.menu.maxspi.24.build.flags.maxspi=-DMAX_SPI=24000000
-adafruit_itsybitsy_m4.menu.maxspi.50=50 MHz
-adafruit_itsybitsy_m4.menu.maxspi.50.build.flags.maxspi=-DMAX_SPI=50000000
-adafruit_itsybitsy_m4.menu.maxspi.fcpu2=CPU Speed / 2
-adafruit_itsybitsy_m4.menu.maxspi.fcpu2.build.flags.maxspi=-DMAX_SPI=({build.f_cpu}/2)
 adafruit_itsybitsy_m4.menu.maxqspi.50=50 MHz (standard)
 adafruit_itsybitsy_m4.menu.maxqspi.50.build.flags.maxqspi=-DVARIANT_QSPI_BAUD_DEFAULT=50000000
 adafruit_itsybitsy_m4.menu.maxqspi.fcpu=CPU Speed / 2
@@ -514,12 +495,6 @@ adafruit_feather_m4.menu.opt.fast=Fast (-O2)
 adafruit_feather_m4.menu.opt.fast.build.flags.optimize=-O2
 adafruit_feather_m4.menu.opt.dragons=Here be dragons (-Ofast -funroll-loops)
 adafruit_feather_m4.menu.opt.dragons.build.flags.optimize=-Ofast -funroll-loops
-adafruit_feather_m4.menu.maxspi.24=24 MHz (standard)
-adafruit_feather_m4.menu.maxspi.24.build.flags.maxspi=-DMAX_SPI=24000000
-adafruit_feather_m4.menu.maxspi.50=50 MHz
-adafruit_feather_m4.menu.maxspi.50.build.flags.maxspi=-DMAX_SPI=50000000
-adafruit_feather_m4.menu.maxspi.fcpu2=CPU Speed / 2
-adafruit_feather_m4.menu.maxspi.fcpu2.build.flags.maxspi=-DMAX_SPI=({build.f_cpu}/2)
 adafruit_feather_m4.menu.maxqspi.50=50 MHz (standard)
 adafruit_feather_m4.menu.maxqspi.50.build.flags.maxqspi=-DVARIANT_QSPI_BAUD_DEFAULT=50000000
 adafruit_feather_m4.menu.maxqspi.fcpu=CPU Speed / 2
@@ -608,12 +583,6 @@ adafruit_trellis_m4.menu.opt.fast=Fast (-O2)
 adafruit_trellis_m4.menu.opt.fast.build.flags.optimize=-O2
 adafruit_trellis_m4.menu.opt.dragons=Here be dragons (-Ofast -funroll-loops)
 adafruit_trellis_m4.menu.opt.dragons.build.flags.optimize=-Ofast -funroll-loops
-adafruit_trellis_m4.menu.maxspi.24=24 MHz (standard)
-adafruit_trellis_m4.menu.maxspi.24.build.flags.maxspi=-DMAX_SPI=24000000
-adafruit_trellis_m4.menu.maxspi.50=50 MHz
-adafruit_trellis_m4.menu.maxspi.50.build.flags.maxspi=-DMAX_SPI=50000000
-adafruit_trellis_m4.menu.maxspi.fcpu2=CPU Speed / 2
-adafruit_trellis_m4.menu.maxspi.fcpu2.build.flags.maxspi=-DMAX_SPI=({build.f_cpu}/2)
 adafruit_trellis_m4.menu.maxqspi.50=50 MHz (standard)
 adafruit_trellis_m4.menu.maxqspi.50.build.flags.maxqspi=-DVARIANT_QSPI_BAUD_DEFAULT=50000000
 adafruit_trellis_m4.menu.maxqspi.fcpu=CPU Speed / 2
@@ -699,12 +668,6 @@ adafruit_pyportal_m4.menu.opt.fast=Fast (-O2)
 adafruit_pyportal_m4.menu.opt.fast.build.flags.optimize=-O2
 adafruit_pyportal_m4.menu.opt.dragons=Here be dragons (-Ofast -funroll-loops)
 adafruit_pyportal_m4.menu.opt.dragons.build.flags.optimize=-Ofast -funroll-loops
-adafruit_pyportal_m4.menu.maxspi.24=24 MHz (standard)
-adafruit_pyportal_m4.menu.maxspi.24.build.flags.maxspi=-DMAX_SPI=24000000
-adafruit_pyportal_m4.menu.maxspi.50=50 MHz
-adafruit_pyportal_m4.menu.maxspi.50.build.flags.maxspi=-DMAX_SPI=50000000
-adafruit_pyportal_m4.menu.maxspi.fcpu2=CPU Speed / 2
-adafruit_pyportal_m4.menu.maxspi.fcpu2.build.flags.maxspi=-DMAX_SPI=({build.f_cpu}/2)
 adafruit_pyportal_m4.menu.maxqspi.50=50 MHz (standard)
 adafruit_pyportal_m4.menu.maxqspi.50.build.flags.maxqspi=-DVARIANT_QSPI_BAUD_DEFAULT=50000000
 adafruit_pyportal_m4.menu.maxqspi.fcpu=CPU Speed / 2
@@ -760,12 +723,6 @@ adafruit_pybadge_m4.menu.opt.fast=Fast (-O2)
 adafruit_pybadge_m4.menu.opt.fast.build.flags.optimize=-O2
 adafruit_pybadge_m4.menu.opt.dragons=Here be dragons (-Ofast -funroll-loops)
 adafruit_pybadge_m4.menu.opt.dragons.build.flags.optimize=-Ofast -funroll-loops
-adafruit_pybadge_m4.menu.maxspi.24=24 MHz (standard)
-adafruit_pybadge_m4.menu.maxspi.24.build.flags.maxspi=-DMAX_SPI=24000000
-adafruit_pybadge_m4.menu.maxspi.50=50 MHz
-adafruit_pybadge_m4.menu.maxspi.50.build.flags.maxspi=-DMAX_SPI=50000000
-adafruit_pybadge_m4.menu.maxspi.fcpu2=CPU Speed / 2
-adafruit_pybadge_m4.menu.maxspi.fcpu2.build.flags.maxspi=-DMAX_SPI=({build.f_cpu}/2)
 adafruit_pybadge_m4.menu.maxqspi.50=50 MHz (standard)
 adafruit_pybadge_m4.menu.maxqspi.50.build.flags.maxqspi=-DVARIANT_QSPI_BAUD_DEFAULT=50000000
 adafruit_pybadge_m4.menu.maxqspi.fcpu=CPU Speed / 2
@@ -819,12 +776,6 @@ adafruit_metro_m4_airliftlite.menu.opt.fast=Fast (-O2)
 adafruit_metro_m4_airliftlite.menu.opt.fast.build.flags.optimize=-O2
 adafruit_metro_m4_airliftlite.menu.opt.dragons=Here be dragons (-Ofast -funroll-loops)
 adafruit_metro_m4_airliftlite.menu.opt.dragons.build.flags.optimize=-Ofast -funroll-loops
-adafruit_metro_m4_airliftlite.menu.maxspi.24=24 MHz (standard)
-adafruit_metro_m4_airliftlite.menu.maxspi.24.build.flags.maxspi=-DMAX_SPI=24000000
-adafruit_metro_m4_airliftlite.menu.maxspi.50=50 MHz
-adafruit_metro_m4_airliftlite.menu.maxspi.50.build.flags.maxspi=-DMAX_SPI=50000000
-adafruit_metro_m4_airliftlite.menu.maxspi.fcpu2=CPU Speed / 2
-adafruit_metro_m4_airliftlite.menu.maxspi.fcpu2.build.flags.maxspi=-DMAX_SPI=({build.f_cpu}/2)
 adafruit_metro_m4_airliftlite.menu.maxqspi.50=50 MHz (standard)
 adafruit_metro_m4_airliftlite.menu.maxqspi.50.build.flags.maxqspi=-DVARIANT_QSPI_BAUD_DEFAULT=50000000
 adafruit_metro_m4_airliftlite.menu.maxqspi.fcpu=CPU Speed / 2
@@ -880,12 +831,6 @@ adafruit_pygamer_m4.menu.opt.fast=Fast (-O2)
 adafruit_pygamer_m4.menu.opt.fast.build.flags.optimize=-O2
 adafruit_pygamer_m4.menu.opt.dragons=Here be dragons (-Ofast -funroll-loops)
 adafruit_pygamer_m4.menu.opt.dragons.build.flags.optimize=-Ofast -funroll-loops
-adafruit_pygamer_m4.menu.maxspi.24=24 MHz (standard)
-adafruit_pygamer_m4.menu.maxspi.24.build.flags.maxspi=-DMAX_SPI=24000000
-adafruit_pygamer_m4.menu.maxspi.50=50 MHz
-adafruit_pygamer_m4.menu.maxspi.50.build.flags.maxspi=-DMAX_SPI=50000000
-adafruit_pygamer_m4.menu.maxspi.fcpu2=CPU Speed / 2
-adafruit_pygamer_m4.menu.maxspi.fcpu2.build.flags.maxspi=-DMAX_SPI=({build.f_cpu}/2)
 adafruit_pygamer_m4.menu.maxqspi.50=50 MHz (standard)
 adafruit_pygamer_m4.menu.maxqspi.50.build.flags.maxqspi=-DVARIANT_QSPI_BAUD_DEFAULT=50000000
 adafruit_pygamer_m4.menu.maxqspi.fcpu=CPU Speed / 2

--- a/cores/arduino/SERCOM.cpp
+++ b/cores/arduino/SERCOM.cpp
@@ -305,7 +305,11 @@ void SERCOM::setBaudrateSPI(uint8_t divider)
 {
   disableSPI(); // Register is enable-protected
 
+#if defined(__SAMD51__)
+  sercom->SPI.BAUD.reg = calculateBaudrateSynchronous(freqRef / divider);
+#else
   sercom->SPI.BAUD.reg = calculateBaudrateSynchronous(SERCOM_SPI_FREQ_REF / divider);
+#endif
 
   enableSPI();
 }
@@ -364,9 +368,12 @@ bool SERCOM::isDataRegisterEmptySPI()
 //  return sercom->SPI.INTFLAG.bit.RXC;
 //}
 
-uint8_t SERCOM::calculateBaudrateSynchronous(uint32_t baudrate)
-{
+uint8_t SERCOM::calculateBaudrateSynchronous(uint32_t baudrate) {
+#if defined(__SAMD51__)
+  uint16_t b = freqRef / (2 * baudrate);
+#else
   uint16_t b = SERCOM_SPI_FREQ_REF / (2 * baudrate);
+#endif
   if(b > 0) b--; // Don't -1 on baud calc if already at 0
   return b;
 }
@@ -664,163 +671,152 @@ uint8_t SERCOM::readDataWIRE( void )
   }
 }
 
-
-void SERCOM::initClockNVIC( void )
-{
 #if defined(__SAMD51__)
-  uint32_t  clk_core, clk_slow;
-  IRQn_Type irq0, irq1, irq2, irq3;
 
-  if(sercom == SERCOM0) {
-    clk_core = SERCOM0_GCLK_ID_CORE;
-    clk_slow = SERCOM0_GCLK_ID_SLOW;
-    irq0     = SERCOM0_0_IRQn;
-    irq1     = SERCOM0_1_IRQn;
-    irq2     = SERCOM0_2_IRQn;
-    irq3     = SERCOM0_3_IRQn;
-  } else if(sercom == SERCOM1) {
-    clk_core = SERCOM1_GCLK_ID_CORE;
-    clk_slow = SERCOM1_GCLK_ID_SLOW;
-    irq0     = SERCOM1_0_IRQn;
-    irq1     = SERCOM1_1_IRQn;
-    irq2     = SERCOM1_2_IRQn;
-    irq3     = SERCOM1_3_IRQn;
-  } else if(sercom == SERCOM2) {
-    clk_core = SERCOM2_GCLK_ID_CORE;
-    clk_slow = SERCOM2_GCLK_ID_SLOW;
-    irq0     = SERCOM2_0_IRQn;
-    irq1     = SERCOM2_1_IRQn;
-    irq2     = SERCOM2_2_IRQn;
-    irq3     = SERCOM2_3_IRQn;
-  } else if(sercom == SERCOM3) {
-    clk_core = SERCOM3_GCLK_ID_CORE;
-    clk_slow = SERCOM3_GCLK_ID_SLOW;
-    irq0     = SERCOM3_0_IRQn;
-    irq1     = SERCOM3_1_IRQn;
-    irq2     = SERCOM3_2_IRQn;
-    irq3     = SERCOM3_3_IRQn;
-  } else if(sercom == SERCOM4) {
-    clk_core = SERCOM4_GCLK_ID_CORE;
-    clk_slow = SERCOM4_GCLK_ID_SLOW;
-    irq0     = SERCOM4_0_IRQn;
-    irq1     = SERCOM4_1_IRQn;
-    irq2     = SERCOM4_2_IRQn;
-    irq3     = SERCOM4_3_IRQn;
-  } else if(sercom == SERCOM5) {
-    clk_core = SERCOM5_GCLK_ID_CORE;
-    clk_slow = SERCOM5_GCLK_ID_SLOW;
-    irq0     = SERCOM5_0_IRQn;
-    irq1     = SERCOM5_1_IRQn;
-    irq2     = SERCOM5_2_IRQn;
-    irq3     = SERCOM5_3_IRQn;
+static const struct {
+  Sercom   *sercomPtr;
+  uint8_t   id_core;
+  uint8_t   id_slow;
+  IRQn_Type irq[4];
+} sercomData[] = {
+  { SERCOM0, SERCOM0_GCLK_ID_CORE, SERCOM0_GCLK_ID_SLOW,
+    SERCOM0_0_IRQn, SERCOM0_1_IRQn, SERCOM0_2_IRQn, SERCOM0_3_IRQn },
+  { SERCOM1, SERCOM1_GCLK_ID_CORE, SERCOM1_GCLK_ID_SLOW,
+    SERCOM1_0_IRQn, SERCOM1_1_IRQn, SERCOM1_2_IRQn, SERCOM1_3_IRQn },
+  { SERCOM2, SERCOM2_GCLK_ID_CORE, SERCOM2_GCLK_ID_SLOW,
+    SERCOM2_0_IRQn, SERCOM2_1_IRQn, SERCOM2_2_IRQn, SERCOM2_3_IRQn },
+  { SERCOM3, SERCOM3_GCLK_ID_CORE, SERCOM3_GCLK_ID_SLOW,
+    SERCOM3_0_IRQn, SERCOM3_1_IRQn, SERCOM3_2_IRQn, SERCOM3_3_IRQn },
+  { SERCOM4, SERCOM4_GCLK_ID_CORE, SERCOM4_GCLK_ID_SLOW,
+    SERCOM4_0_IRQn, SERCOM4_1_IRQn, SERCOM4_2_IRQn, SERCOM4_3_IRQn },
+  { SERCOM5, SERCOM5_GCLK_ID_CORE, SERCOM5_GCLK_ID_SLOW,
+    SERCOM5_0_IRQn, SERCOM5_1_IRQn, SERCOM5_2_IRQn, SERCOM5_3_IRQn },
+#if defined(SERCOM6)
+  { SERCOM6, SERCOM6_GCLK_ID_CORE, SERCOM6_GCLK_ID_SLOW,
+    SERCOM6_0_IRQn, SERCOM6_1_IRQn, SERCOM6_2_IRQn, SERCOM6_3_IRQn },
+#endif
+#if defined(SERCOM7)
+  { SERCOM7, SERCOM7_GCLK_ID_CORE, SERCOM7_GCLK_ID_SLOW,
+    SERCOM7_0_IRQn, SERCOM7_1_IRQn, SERCOM7_2_IRQn, SERCOM7_3_IRQn },
+#endif
+};
+
+#else // end if SAMD51 (prob SAMD21)
+
+static const struct {
+  Sercom   *sercomPtr;
+  uint8_t   clock;
+  IRQn_Type irqn;
+} sercomData[] = {
+  SERCOM0, GCM_SERCOM0_CORE, SERCOM0_IRQn,
+  SERCOM1, GCM_SERCOM1_CORE, SERCOM1_IRQn,
+  SERCOM2, GCM_SERCOM2_CORE, SERCOM2_IRQn,
+  SERCOM3, GCM_SERCOM3_CORE, SERCOM3_IRQn,
+#if defined(SERCOM4)
+  SERCOM4, GCM_SERCOM4_CORE, SERCOM4_IRQn,
+#endif
+#if defined(SERCOM5)
+  SERCOM5, GCM_SERCOM5_CORE, SERCOM5_IRQn,
+#endif
+};
+
+#endif // end !SAMD51
+
+int8_t SERCOM::getSercomIndex(void) {
+  for(uint8_t i=0; i<(sizeof(sercomData) / sizeof(sercomData[0])); i++) {
+    if(sercom == sercomData[i].sercomPtr) return i;
   }
- #if defined SERCOM6
-  else if(sercom == SERCOM6) {
-    clk_core = SERCOM6_GCLK_ID_CORE;
-    clk_slow = SERCOM6_GCLK_ID_SLOW;
-    irq0     = (SERCOM6_0_IRQn);
-    irq1     = (SERCOM6_1_IRQn);
-    irq2     = (SERCOM6_2_IRQn);
-    irq3     = (SERCOM6_3_IRQn);
-  }
- #endif // end SERCOM6
- #if defined SERCOM7
-  else if(sercom == SERCOM7) {
-    clk_core = SERCOM7_GCLK_ID_CORE;
-    clk_slow = SERCOM7_GCLK_ID_SLOW;
-    irq0     = (SERCOM7_0_IRQn);
-    irq1     = (SERCOM7_1_IRQn);
-    irq2     = (SERCOM7_2_IRQn);
-    irq3     = (SERCOM7_3_IRQn);
-  }
- #endif // end SERCOM7
-  NVIC_ClearPendingIRQ(irq0);
-  NVIC_ClearPendingIRQ(irq1);
-  NVIC_ClearPendingIRQ(irq2);
-  NVIC_ClearPendingIRQ(irq3);
+  return -1;
+}
 
-  NVIC_SetPriority(irq0, (1<<__NVIC_PRIO_BITS) - 1);
-  NVIC_SetPriority(irq1, (1<<__NVIC_PRIO_BITS) - 1);
-  NVIC_SetPriority(irq2, (1<<__NVIC_PRIO_BITS) - 1);
-  NVIC_SetPriority(irq3, (1<<__NVIC_PRIO_BITS) - 1);
+#if defined(__SAMD51__)
+// This is currently for overriding an SPI SERCOM's clock source only --
+// NOT for UART or WIRE SERCOMs, where it will have unintended consequences.
+// It does not check.
+void SERCOM::setClockSource(int idx, SercomClockSource src, bool core) {
 
-  NVIC_EnableIRQ(irq0);
-  NVIC_EnableIRQ(irq1);
-  NVIC_EnableIRQ(irq2);
-  NVIC_EnableIRQ(irq3);
+  uint8_t clk_id = core ? sercomData[idx].id_core : sercomData[idx].id_slow;
 
-  GCLK->PCHCTRL[clk_core].bit.CHEN = 0;     // Disable core timer
-  while(GCLK->PCHCTRL[clk_core].bit.CHEN);  // Wait for disable
-  GCLK->PCHCTRL[clk_slow].bit.CHEN = 0;     // Disable slow timer
-  while(GCLK->PCHCTRL[clk_slow].bit.CHEN);  // Wait for disable
+  GCLK->PCHCTRL[clk_id].bit.CHEN = 0;     // Disable timer
+  while(GCLK->PCHCTRL[clk_id].bit.CHEN);  // Wait for disable
 
-  // SPI DMA speed is dictated by the "slow clock," so BOTH are set to the
-  // same clock source (clk_slow isn't sourced from XOSC32K as before).
-  // This might have power implications for sleep code.
   // From cores/arduino/startup.c:
   // GCLK0 = F_CPU
   // GCLK1 = 48 MHz
   // GCLK2 = 100 MHz
   // GCLK3 = XOSC32K
   // GCLK4 = 12 MHz
- #if SERCOM_SPI_FREQ_REF == 48000000 // 48 MHz clock = GCLK1
-  GCLK->PCHCTRL[clk_core].reg = GCLK_PCHCTRL_GEN_GCLK1_Val |
-                                (1 << GCLK_PCHCTRL_CHEN_Pos);
-  GCLK->PCHCTRL[clk_slow].reg = GCLK_PCHCTRL_GEN_GCLK1_Val |
-                                (1 << GCLK_PCHCTRL_CHEN_Pos);
+  if(src == SERCOM_CLOCK_SOURCE_FCPU) {
+    GCLK->PCHCTRL[clk_id].reg =
+      GCLK_PCHCTRL_GEN_GCLK0_Val | (1 << GCLK_PCHCTRL_CHEN_Pos);
+    if(core) freqRef = F_CPU;
+  } else if(src == SERCOM_CLOCK_SOURCE_48M) {
+    GCLK->PCHCTRL[clk_id].reg =
+      GCLK_PCHCTRL_GEN_GCLK1_Val | (1 << GCLK_PCHCTRL_CHEN_Pos);
+    if(core) freqRef = 48000000;
+  } else if(src == SERCOM_CLOCK_SOURCE_100M) {
+    GCLK->PCHCTRL[clk_id].reg =
+      GCLK_PCHCTRL_GEN_GCLK2_Val | (1 << GCLK_PCHCTRL_CHEN_Pos);
+    if(core) freqRef = 100000000;
+  } else if(src == SERCOM_CLOCK_SOURCE_32K) {
+    GCLK->PCHCTRL[clk_id].reg =
+      GCLK_PCHCTRL_GEN_GCLK3_Val | (1 << GCLK_PCHCTRL_CHEN_Pos);
+    if(core) freqRef = 32768;
+  } else if(src == SERCOM_CLOCK_SOURCE_12M) {
+    GCLK->PCHCTRL[clk_id].reg =
+      GCLK_PCHCTRL_GEN_GCLK4_Val | (1 << GCLK_PCHCTRL_CHEN_Pos);
+    if(core) freqRef = 12000000;
+  }
+
+  while(!GCLK->PCHCTRL[clk_id].bit.CHEN); // Wait for clock enable
+}
+#endif
+
+void SERCOM::initClockNVIC( void )
+{
+  int8_t idx = getSercomIndex();
+  if(idx < 0) return; // We got a problem here
+
+#if defined(__SAMD51__)
+
+  for(uint8_t i=0; i<4; i++) {
+    NVIC_ClearPendingIRQ(sercomData[idx].irq[i]);
+    NVIC_SetPriority(sercomData[idx].irq[i], SERCOM_NVIC_PRIORITY);
+    NVIC_EnableIRQ(sercomData[idx].irq[i]);
+  }
+
+  // A briefly-availabe but now deprecated feature had the SPI clock source
+  // set via a compile-time setting (MAX_SPI)...problem was this affected
+  // ALL SERCOMs, whereas some (anything read/write, e.g. SD cards) should
+  // not exceed the standard 24 MHz setting.  Newer code, if it needs faster
+  // write-only SPI (e.g. to screen), should override the SERCOM clock on a
+  // per-peripheral basis.  Nonetheless, we check SERCOM_SPI_FREQ_REF here
+  // (MAX_SPI * 2) to retain compatibility with any interim projects that
+  // might have relied on the compile-time setting.  But please, don't.
+
+  // SPI DMA speed is dictated by the "slow clock," so BOTH are set to the
+  // same clock source (clk_slow isn't sourced from XOSC32K as before).
+  // This might have power implications for sleep code.
+
+ #if SERCOM_SPI_FREQ_REF == F_CPU       // F_CPU clock = GCLK0
+  setClockSource(idx, SERCOM_CLOCK_SOURCE_FCPU, true);  // true  = core clock
+  setClockSource(idx, SERCOM_CLOCK_SOURCE_FCPU, false); // false = slow clock
+ #elif SERCOM_SPI_FREQ_REF == 48000000  // 48 MHz clock = GCLK1 (standard)
+  setClockSource(idx, SERCOM_CLOCK_SOURCE_48M , true);
+  setClockSource(idx, SERCOM_CLOCK_SOURCE_48M , false);
  #elif SERCOM_SPI_FREQ_REF == 100000000 // 100 MHz clock = GCLK2
-  GCLK->PCHCTRL[clk_core].reg = GCLK_PCHCTRL_GEN_GCLK2_Val |
-                                (1 << GCLK_PCHCTRL_CHEN_Pos);
-  GCLK->PCHCTRL[clk_slow].reg = GCLK_PCHCTRL_GEN_GCLK2_Val |
-                                (1 << GCLK_PCHCTRL_CHEN_Pos);
- #elif SERCOM_SPI_FREQ_REF == F_CPU // F_CPU clock = GCLK0
-  GCLK->PCHCTRL[clk_core].reg = GCLK_PCHCTRL_GEN_GCLK0_Val |
-                                (1 << GCLK_PCHCTRL_CHEN_Pos);
-  GCLK->PCHCTRL[clk_slow].reg = GCLK_PCHCTRL_GEN_GCLK0_Val |
-                                (1 << GCLK_PCHCTRL_CHEN_Pos);
+  setClockSource(idx, SERCOM_CLOCK_SOURCE_100M, true);
+  setClockSource(idx, SERCOM_CLOCK_SOURCE_100M, false);
  #endif
 
-  while(!GCLK->PCHCTRL[clk_core].bit.CHEN); // Wait for core clock enable
-  while(!GCLK->PCHCTRL[clk_slow].bit.CHEN); // Wait for slow clock enable
+#else // end if SAMD51 (prob SAMD21)
 
-#else // end if SAMD51
+  uint8_t   clockId = sercomData[idx].clock;
+  IRQn_Type IdNvic  = sercomData[idx].irqn;
 
-  IRQn_Type IdNvic=PendSV_IRQn ; // Dummy init to intercept potential error later
-
-  uint8_t clockId = 0;
-  if(sercom == SERCOM0) {
-    clockId = GCM_SERCOM0_CORE;
-    IdNvic  = SERCOM0_IRQn;
-  } else if(sercom == SERCOM1) {
-    clockId = GCM_SERCOM1_CORE;
-    IdNvic  = SERCOM1_IRQn;
-  } else if(sercom == SERCOM2) {
-    clockId = GCM_SERCOM2_CORE;
-    IdNvic  = SERCOM2_IRQn;
-  } else if(sercom == SERCOM3) {
-    clockId = GCM_SERCOM3_CORE;
-    IdNvic  = SERCOM3_IRQn;
-  }
- #if defined(SERCOM4)
-  else if(sercom == SERCOM4) {
-    clockId = GCM_SERCOM4_CORE;
-    IdNvic  = SERCOM4_IRQn;
-  }
- #endif // end SERCOM4
- #if defined(SERCOM5)
-  else if(sercom == SERCOM5) {
-    clockId = GCM_SERCOM5_CORE;
-    IdNvic  = SERCOM5_IRQn;
-  }
- #endif // end SERCOM5
-
-  if(IdNvic == PendSV_IRQn) {
-    return; // We got a problem here
-  }
-
-    // Setting NVIC
+  // Setting NVIC
   NVIC_ClearPendingIRQ(IdNvic);
-  NVIC_SetPriority (IdNvic, (1<<__NVIC_PRIO_BITS) - 1);
+  NVIC_SetPriority(IdNvic, SERCOM_NVIC_PRIORITY);
   NVIC_EnableIRQ(IdNvic);
 
   // Setting clock
@@ -830,5 +826,6 @@ void SERCOM::initClockNVIC( void )
     GCLK_CLKCTRL_CLKEN;
 
   while(GCLK->STATUS.reg & GCLK_STATUS_SYNCBUSY); // Wait for synchronization
+
 #endif // end !SAMD51
 }

--- a/cores/arduino/SERCOM.cpp
+++ b/cores/arduino/SERCOM.cpp
@@ -751,6 +751,9 @@ int8_t SERCOM::getSercomIndex(void) {
 // This is currently for overriding an SPI SERCOM's clock source only --
 // NOT for UART or WIRE SERCOMs, where it will have unintended consequences.
 // It does not check.
+// SERCOM clock source override is available only on SAMD51 (not 21).
+// A dummy function for SAMD21 (compiles to nothing) is present in SERCOM.h
+// so user code doesn't require a lot of conditional situations.
 void SERCOM::setClockSource(int8_t idx, SercomClockSource src, bool core) {
 
   if(src == SERCOM_CLOCK_SOURCE_NO_CHANGE) return;
@@ -794,7 +797,6 @@ void SERCOM::setClockSource(int8_t idx, SercomClockSource src, bool core) {
 }
 #endif
 
-
 void SERCOM::initClockNVIC( void )
 {
   int8_t idx = getSercomIndex();
@@ -808,8 +810,9 @@ void SERCOM::initClockNVIC( void )
     NVIC_EnableIRQ(sercomData[idx].irq[i]);
   }
 
-  // SPI DMA speed is dictated by the "slow clock," so BOTH are set to the
-  // same clock source (clk_slow isn't sourced from XOSC32K as before).
+  // SPI DMA speed is dictated by the "slow clock" (I think...maybe) so
+  // BOTH are set to the same clock source (clk_slow isn't sourced from
+  // XOSC32K as in prior versions of SAMD core).
   // This might have power implications for sleep code.
 
   setClockSource(idx, clockSource, true);  // true  = core clock

--- a/cores/arduino/SERCOM.h
+++ b/cores/arduino/SERCOM.h
@@ -233,13 +233,15 @@ class SERCOM
 		uint8_t readDataWIRE( void ) ;
 		int8_t getSercomIndex(void);
 #if defined(__SAMD51__)
-		void setClockSource(int idx, SercomClockSource src, bool core);
+		void setClockSource(int8_t idx, SercomClockSource src, bool core);
+		SercomClockSource getClockSource(void) { return clockSource; };
 		uint32_t getFreqRef(void) { return freqRef; };
 #endif
 
 	private:
 		Sercom* sercom;
 #if defined(__SAMD51__)
+                SercomClockSource clockSource;
                 uint32_t freqRef;
 #endif
 		uint8_t calculateBaudrateSynchronous(uint32_t baudrate);

--- a/cores/arduino/SERCOM.h
+++ b/cores/arduino/SERCOM.h
@@ -152,7 +152,10 @@ typedef enum
 	WIRE_MASTER_NACK_ACTION
 } SercomMasterAckActionWire;
 
-#if defined(__SAMD51__)
+// SERCOM clock source override is available only on SAMD51 (not 21)
+// but the enumeration is made regardless so user code doesn't need
+// ifdefs or lengthy comments explaining the different situations --
+// the clock-sourcing functions just compile to nothing on SAMD21.
 typedef enum SercomClockSource {
   SERCOM_CLOCK_SOURCE_FCPU,     // F_CPU clock (GCLK0)
   SERCOM_CLOCK_SOURCE_48M,      // 48 MHz peripheral clock (GCLK1) (standard)
@@ -161,7 +164,6 @@ typedef enum SercomClockSource {
   SERCOM_CLOCK_SOURCE_12M,      // 12 MHz peripheral clock (GCLK4)
   SERCOM_CLOCK_SOURCE_NO_CHANGE // Leave clock source setting unchanged
 };
-#endif // end __SAMD51__
 
 class SERCOM
 {
@@ -233,16 +235,26 @@ class SERCOM
 		uint8_t readDataWIRE( void ) ;
 		int8_t getSercomIndex(void);
 #if defined(__SAMD51__)
+		// SERCOM clock source override is only available on
+		// SAMD51 (not 21) ... but these functions are declared
+		// regardless so user code doesn't need ifdefs or lengthy
+		// comments explaining the different situations -- these
+		// just compile to nothing on SAMD21.
 		void setClockSource(int8_t idx, SercomClockSource src, bool core);
 		SercomClockSource getClockSource(void) { return clockSource; };
 		uint32_t getFreqRef(void) { return freqRef; };
+#else
+		// The equivalent SAMD21 dummy functions...
+		void setClockSource(int8_t idx, SercomClockSource src, bool core) { };
+		SercomClockSource getClockSource(void) { return SERCOM_CLOCK_SOURCE_FCPU; };
+		uint32_t getFreqRef(void) { return F_CPU; };
 #endif
 
 	private:
 		Sercom* sercom;
 #if defined(__SAMD51__)
                 SercomClockSource clockSource;
-                uint32_t freqRef;
+                uint32_t freqRef; // Frequency corresponding to clockSource
 #endif
 		uint8_t calculateBaudrateSynchronous(uint32_t baudrate);
 		uint32_t division(uint32_t dividend, uint32_t divisor) ;

--- a/libraries/SPI/SPI.cpp
+++ b/libraries/SPI/SPI.cpp
@@ -42,10 +42,6 @@ SPIClass::SPIClass(SERCOM *p_sercom, uint8_t uc_pinMISO, uint8_t uc_pinSCK, uint
   // SERCOM pads
   _padTx=PadTx;
   _padRx=PadRx;
-
-#if defined(__SAMD51__)
-  maxBitrate = MAX_SPI; // Can override via setClockSource()
-#endif
 }
 
 void SPIClass::begin()
@@ -247,7 +243,6 @@ void SPIClass::detachInterrupt() {
   // Should be disableInterrupt()
 }
 
-#if defined(__SAMD21__) || defined(__SAMD51__)
 // SPI DMA lookup works on both SAMD21 and SAMD51
 
 volatile uint32_t *SPIClass::getDataRegister(void) {
@@ -282,16 +277,17 @@ int SPIClass::getDMACID(void) {
   return (idx >= 0) ? DMACID[idx] : -1;
 }
 
-#endif // end __SAMD21__ || __SAMD51__
-
 #if defined(__SAMD51__)
 
-// Set the SPI device's SERCOM clock CORE and/or SLOW clock source(s).
-// These are SercomClockSource values from an enumeration in SERCOM.h.
-void SPIClass::setClockSources(SercomClockSource core, SercomClockSource slow) {
+// Set the SPI device's SERCOM clock CORE and SLOW clock sources.
+// SercomClockSource values are an enumeration in SERCOM.h.
+// This works on SAMD51 only.  On SAMD21, a dummy function is declared
+// in SPI.h which compiles to nothing, so user code doesn't need to check
+// and conditionally compile lines for different architectures.
+void SPIClass::setClockSource(SercomClockSource clk) {
   int8_t idx = _p_sercom->getSercomIndex();
-  _p_sercom->setClockSource(idx, core, true);  // true  = set core clock
-  _p_sercom->setClockSource(idx, slow, false); // false = set slow clock
+  _p_sercom->setClockSource(idx, clk, true);  // true  = set core clock
+  _p_sercom->setClockSource(idx, clk, false); // false = set slow clock
 }
 
 #endif // end __SAMD51__

--- a/libraries/SPI/SPI.cpp
+++ b/libraries/SPI/SPI.cpp
@@ -245,36 +245,38 @@ void SPIClass::detachInterrupt() {
 
 // SPI DMA lookup works on both SAMD21 and SAMD51
 
-volatile uint32_t *SPIClass::getDataRegister(void) {
-  volatile uint32_t *dataReg[] = {
-    &SERCOM0->SPI.DATA.reg, &SERCOM1->SPI.DATA.reg, &SERCOM2->SPI.DATA.reg,
-    &SERCOM3->SPI.DATA.reg, &SERCOM4->SPI.DATA.reg, &SERCOM5->SPI.DATA.reg,
+static const struct {
+  volatile uint32_t *data_reg;
+  int                dmac_id_tx;
+  int                dmac_id_rx;
+} sercomData[] = {
+  { &SERCOM0->SPI.DATA.reg, SERCOM0_DMAC_ID_TX, SERCOM0_DMAC_ID_RX },
+  { &SERCOM1->SPI.DATA.reg, SERCOM1_DMAC_ID_TX, SERCOM1_DMAC_ID_RX },
+  { &SERCOM2->SPI.DATA.reg, SERCOM2_DMAC_ID_TX, SERCOM2_DMAC_ID_RX },
+  { &SERCOM3->SPI.DATA.reg, SERCOM3_DMAC_ID_TX, SERCOM3_DMAC_ID_RX },
+  { &SERCOM4->SPI.DATA.reg, SERCOM4_DMAC_ID_TX, SERCOM4_DMAC_ID_RX },
+  { &SERCOM5->SPI.DATA.reg, SERCOM5_DMAC_ID_TX, SERCOM5_DMAC_ID_RX },
 #if defined(SERCOM6)
-    &SERCOM6->SPI.DATA.reg,
+  { &SERCOM6->SPI.DATA.reg, SERCOM6_DMAC_ID_TX, SERCOM6_DMAC_ID_RX },
 #endif
 #if defined(SERCOM7)
-    &SERCOM7->SPI.DATA.reg,
+  { &SERCOM7->SPI.DATA.reg, SERCOM7_DMAC_ID_TX, SERCOM7_DMAC_ID_RX },
 #endif
-  };
+};
 
+volatile uint32_t *SPIClass::getDataRegister(void) {
   int8_t idx = _p_sercom->getSercomIndex();
-  return (idx >= 0) ? dataReg[idx]: NULL;
+  return (idx >= 0) ? sercomData[idx].data_reg: NULL;
 }
 
-int SPIClass::getDMACID(void) {
-  int DMACID[] = {
-    SERCOM0_DMAC_ID_TX, SERCOM1_DMAC_ID_TX, SERCOM2_DMAC_ID_TX,
-    SERCOM3_DMAC_ID_TX, SERCOM4_DMAC_ID_TX, SERCOM5_DMAC_ID_TX,
-#if defined(SERCOM6)
-    SERCOM6_DMAC_ID_TX,
-#endif
-#if defined(SERCOM7)
-    SERCOM7_DMAC_ID_TX,
-#endif
-  };
-
+int SPIClass::getDMAC_ID_TX(void) {
   int8_t idx = _p_sercom->getSercomIndex();
-  return (idx >= 0) ? DMACID[idx] : -1;
+  return (idx >= 0) ? sercomData[idx].dmac_id_tx : -1;
+}
+
+int SPIClass::getDMAC_ID_RX(void) {
+  int8_t idx = _p_sercom->getSercomIndex();
+  return (idx >= 0) ? sercomData[idx].dmac_id_rx : -1;
 }
 
 #if defined(__SAMD51__)

--- a/libraries/SPI/SPI.h
+++ b/libraries/SPI/SPI.h
@@ -134,7 +134,8 @@ class SPIClass {
 
   // SERCOM lookup functions are available on both SAMD51 and 21.
   volatile uint32_t *getDataRegister(void);
-  int getDMACID(void);
+  int getDMAC_ID_TX(void);
+  int getDMAC_ID_RX(void);
   uint8_t getSercomIndex(void) { return _p_sercom->getSercomIndex(); };
 #if defined(__SAMD51__)
   // SERCOM clock source override is available only on SAMD51.


### PR DESCRIPTION
**DEPRECATES the M4 MAX_SPI compile-time setting** (and corresponding "Max SPI" menu) in favor of **run-time** SPI SERCOM clock options. MAX_SPI is still handled for any interim projects that required it, but it should not be used or needed going forward (it had problems in that it affected ALL SERCOMs, not just one SPI peripheral, and this caused problems with SD card access and likely other things as well).

Instead, the SPI library now provides the SPI.setClockSource(x) function, where x is one of SERCOM_CLOCK_SOURCE_48M (standard), SERCOM_CLOCK_SOURCE_100M (up to 50 MHz SPI) or SERCOM_CLOCK_SOURCE_FCPU (up to F_CPU/2 SPI). This can be called before or after SPI.begin(), and should also work on SPI1 and any “manually built” SERCOM SPI objects. This has no effect on M0 devices, but the function and enum are still present in that case to avoid confusion if novices copy-and-paste M4 code to an M0 project (SPI will just run at the standard 12 MHz max there).

ADDITIONALLY, the SPI library now provides the following functions:
- SPI.getDataRegister() returns a volatile uint32_t pointer which is the underlying SERCOM DATA register, required for DMA operations (but which was tricky to access before).
- SPI.getDMAC_ID_TX() returns the SERCOM DMAC TX identifier (an integer), again required by certain DMA operations. There is a corresponding getDMAC_ID_RX() function as well.
- SPI.getSercomIndex() returns the underlying SERCOM index (an integer), e.g. 0 for SERCOM0, 1 for SERCOM1 and so forth (up to 5=SERCOM5 on most SAMD21s or 7=SERCOM7 on SAMD51). This is a catch-all should a project require other pointers or identifiers related to a SERCOM...a table of values can be used with this as an index.

(There's some underlying stuff going on in the core SERCOM.h and SERCOM.cpp files to support these changes, but this likely won't affect normal end users. At most they'll use the SPI library functions, and only in rare circumstances.)