### PR TITLE
USBCore: Read the SAMD51 serial number

### DIFF
--- a/cores/arduino/USB/USBCore.cpp
+++ b/cores/arduino/USB/USBCore.cpp
@@ -244,26 +244,25 @@ bool USBDeviceClass::sendDescriptor(USBSetup &setup)
 		}
 		else if (setup.wValueL == ISERIAL) {
 #ifdef PLUGGABLE_USB_ENABLED
-#if defined(__SAMD51__)
-			char name[ISERIAL_MAX_LEN];
-			PluggableUSB().getShortName(name);
-			return sendStringDescriptor((uint8_t*)name, setup.wLength);
-#else
+#ifdef __SAMD51__
+			#define SERIAL_NUMBER_WORD_0	*(volatile uint32_t*)(0x008061FC)
+			#define SERIAL_NUMBER_WORD_1	*(volatile uint32_t*)(0x00806010)
+			#define SERIAL_NUMBER_WORD_2	*(volatile uint32_t*)(0x00806014)
+			#define SERIAL_NUMBER_WORD_3	*(volatile uint32_t*)(0x00806018)
+#else // samd21
 			// from section 9.3.3 of the datasheet
 			#define SERIAL_NUMBER_WORD_0	*(volatile uint32_t*)(0x0080A00C)
 			#define SERIAL_NUMBER_WORD_1	*(volatile uint32_t*)(0x0080A040)
 			#define SERIAL_NUMBER_WORD_2	*(volatile uint32_t*)(0x0080A044)
 			#define SERIAL_NUMBER_WORD_3	*(volatile uint32_t*)(0x0080A048)
-
+#endif
 			char name[ISERIAL_MAX_LEN];
 			utox8(SERIAL_NUMBER_WORD_0, &name[0]);
 			utox8(SERIAL_NUMBER_WORD_1, &name[8]);
 			utox8(SERIAL_NUMBER_WORD_2, &name[16]);
 			utox8(SERIAL_NUMBER_WORD_3, &name[24]);
-
-			PluggableUSB().getShortName(&name[32]);
+			name[32] = '\0';
 			return sendStringDescriptor((uint8_t*)name, setup.wLength);
-#endif
 #endif
 		}
 		else {


### PR DESCRIPTION
Export the unique hardware serial number from the SAMD51 MCU
to the USB device descriptor.

Remove the concatenation of the USB class device string, it is
superfluous, and an USB interface property should not become a
part of the USB device property.

Tested on SAMD21 and SAMD51:

Before:
  SAMD21: 10BD8E4051504C3750202020FF0B1410MIDI
  SAMD51: MIDI

After:
  SAMD21: 10BD8E4051504C3750202020FF0B1410
  SAMD51: AAFC165853574E514D202020FF083C44