### PR TITLE
Fix samd51 ram macro

### DIFF
--- a/cores/arduino/avr/io.h
+++ b/cores/arduino/avr/io.h
@@ -25,8 +25,14 @@
 #ifndef _IO_H_
 #define _IO_H_
 
-#define RAMSTART (HMCRAMC0_ADDR)
-#define RAMSIZE  (HMCRAMC0_SIZE)
+#ifdef HSRAM_ADDR
+  #define RAMSTART (HSRAM_ADDR)
+  #define RAMSIZE  (HSRAM_SIZE)
+#else
+  #define RAMSTART (HMCRAMC0_ADDR)
+  #define RAMSIZE  (HMCRAMC0_SIZE)
+#endif
+
 #define RAMEND   (RAMSTART + RAMSIZE - 1)
 
 #endif

--- a/cores/arduino/avr/io.h
+++ b/cores/arduino/avr/io.h
@@ -25,7 +25,7 @@
 #ifndef _IO_H_
 #define _IO_H_
 
-#ifdef HSRAM_ADDR
+#ifdef __SAMD51__
   #define RAMSTART (HSRAM_ADDR)
   #define RAMSIZE  (HSRAM_SIZE)
 #else


### PR DESCRIPTION
RAMSTART, RAMEND is not defined correctly for SAMD51 which cause travis build on SdFat failed since some of its example use these macros 

@ladyada  for review