### PR TITLE
Remove analog

### DIFF
--- a/variants/grand_central_m4/variant.h
+++ b/variants/grand_central_m4/variant.h
@@ -59,9 +59,9 @@ extern "C"
 // Number of pins defined in PinDescription array
 #define PINS_COUNT           (94u)
 #define NUM_DIGITAL_PINS     (53u)
-#define NUM_ANALOG_INPUTS    (19u)
+#define NUM_ANALOG_INPUTS    (18u)
 #define NUM_ANALOG_OUTPUTS   (2u)
-#define analogInputToDigitalPin(p) ((p < 8) ? 67 + (p) : (p < 16) ? 54 + (p) - 8 : (p < 18) ? 12 + (p) - 16 : (p == 18) ? 9 : -1)
+#define analogInputToDigitalPin(p) ((p < 8) ? 67 + (p) : (p < 16) ? 54 + (p) - 8 : (p == 16) ? 12 : (p == 17) ? 9 : -1)
 
 #define digitalPinToPort(P)        ( &(PORT->Group[g_APinDescription[P].ulPort]) )
 #define digitalPinToBitMask(P)     ( 1 << g_APinDescription[P].ulPin )


### PR DESCRIPTION
Due to hardware components (led and resistor) D13 may not be used as analog