### PR TITLE
Standardize pins count

### DIFF
--- a/variants/grand_central_m4/variant.h
+++ b/variants/grand_central_m4/variant.h
@@ -57,10 +57,10 @@ extern "C"
  *----------------------------------------------------------------------------*/
 
 // Number of pins defined in PinDescription array
-#define PINS_COUNT           (94u)
-#define NUM_DIGITAL_PINS     (53u)
-#define NUM_ANALOG_INPUTS    (19u)
-#define NUM_ANALOG_OUTPUTS   (2u)
+#define PINS_COUNT           (94)
+#define NUM_DIGITAL_PINS     (53)
+#define NUM_ANALOG_INPUTS    (19)
+#define NUM_ANALOG_OUTPUTS   (2)
 #define analogInputToDigitalPin(p) ((p < 8) ? 67 + (p) : (p < 16) ? 54 + (p) - 8 : (p < 18) ? 12 + (p) - 16 : (p == 18) ? 9 : -1)
 
 #define digitalPinToPort(P)        ( &(PORT->Group[g_APinDescription[P].ulPort]) )


### PR DESCRIPTION
Arduino framework doesn't force unsigned (checked in different boards).
This also prevent undesired warnings in Marlin Firmware