### PR TITLE
Fix tone

### DIFF
--- a/cores/arduino/Tone.cpp
+++ b/cores/arduino/Tone.cpp
@@ -37,9 +37,9 @@ volatile bool toneIsActive = false;
 volatile bool firstTimeRunning = false;
 
 #if defined(__SAMD51__)
-#define TONE_TC         TC3
-#define TONE_TC_IRQn    TC3_IRQn
-#define TONE_TC_GCLK_ID	TC3_GCLK_ID
+#define TONE_TC         TC2
+#define TONE_TC_IRQn    TC2_IRQn
+#define TONE_TC_GCLK_ID	TC2_GCLK_ID
 #else
 #define TONE_TC         TC5
 #define TONE_TC_IRQn    TC5_IRQn
@@ -80,10 +80,10 @@ void tone (uint32_t outputPin, uint32_t frequency, uint32_t duration)
   {
     firstTimeRunning = true;
     
-    NVIC_SetPriority(TONE_TC_IRQn, 0);
+    NVIC_SetPriority(TONE_TC_IRQn, 5);
 
 #if defined(__SAMD51__)
-	GCLK->PCHCTRL[TONE_TC_GCLK_ID].reg = GCLK_PCHCTRL_GEN_GCLK0_Val | (1 << GCLK_PCHCTRL_CHEN_Pos);
+	  GCLK->PCHCTRL[TONE_TC_GCLK_ID].reg = GCLK_PCHCTRL_GEN_GCLK0_Val | (1 << GCLK_PCHCTRL_CHEN_Pos);
 #else
     // Enable GCLK for TC4 and TC5 (timer counter input clock)
     GCLK->CLKCTRL.reg = (uint16_t) (GCLK_CLKCTRL_CLKEN | GCLK_CLKCTRL_GEN_GCLK0 | GCLK_CLKCTRL_ID(GCM_TC4_TC5));
@@ -167,8 +167,8 @@ void tone (uint32_t outputPin, uint32_t frequency, uint32_t duration)
     lastOutputPin = outputPin;
     digitalWrite(outputPin, LOW);
     pinMode(outputPin, OUTPUT);
-    toneIsActive = true;
   }
+  toneIsActive = true;
 
   // Enable TONE_TC
   TONE_TC->COUNT16.CTRLA.reg |= TC_CTRLA_ENABLE;


### PR DESCRIPTION
- match timer and timer handler
- lower interrupt priority (0 seems to big for a simple tone)
- be sure 'toneIsActive' is always set (if previous tone was using a different pin, it will not be set)