### PR TITLE
tinyusb: correct SAMD51 serial number extraction

### DIFF
--- a/cores/arduino/Adafruit_TinyUSB_Core/Adafruit_TinyUSB_Core.cpp
+++ b/cores/arduino/Adafruit_TinyUSB_Core/Adafruit_TinyUSB_Core.cpp
@@ -99,7 +99,7 @@ uint8_t load_serial_number(uint16_t* serial_str)
 
   for (int i=0; i<4; i++) {
       for (int k=0; k<4; k++) {
-          raw_id[4 * i + k] = (*(id_addresses[i]) >> k * 8) & 0xff;
+          raw_id[4 * i + (3 - k)] = (*(id_addresses[i]) >> k * 8) & 0xff;
       }
   }
 
@@ -109,7 +109,7 @@ uint8_t load_serial_number(uint16_t* serial_str)
     for (int j = 0; j < 2; j++) {
       uint8_t nibble = (raw_id[i] >> (j * 4)) & 0xf;
       // Strings are UTF-16-LE encoded.
-      serial_str[i * 2 + j] = nibble_to_hex[nibble];
+      serial_str[i * 2 + (1 - j)] = nibble_to_hex[nibble];
     }
   }
 


### PR DESCRIPTION
TinyUSB does not match the exported serial numbers of the classic USB
stack.

The current code serializes the 32-bit words backwards, and the byte
nibbles are also backwards serialized.

A SAMD51 is exported like:
 EFADAF3113347335020202938343E0FF

while it should read:
  13FADAFE5337433139202020FF0E3438