### PR TITLE
Fix compilation warning

### DIFF
--- a/cores/arduino/pulse.c
+++ b/cores/arduino/pulse.c
@@ -41,7 +41,7 @@ uint32_t pulseIn(uint32_t pin, uint32_t state, uint32_t timeout)
    * No assembly required, no conversion of loop counts to times (which is
    * worrisome in the presence of cache.)
    */
-  volatile uint32_t *port = &(PORT->Group[p.ulPort].IN.reg);
+  const volatile uint32_t *port = &(PORT->Group[p.ulPort].IN.reg);
   uint32_t usCallStart;  // microseconds at start of call, for timeout.
   uint32_t usPulseStart; // microseconds at start of measured pulse.
   usCallStart = usPulseStart = micros();


### PR DESCRIPTION
Add 'const' declaration to avoid:
  cores/arduino/pulse.c: In function 'pulseIn':
    cores/arduino/pulse.c:44:29: warning: initialization discards
  'const' qualifier from pointer target type [enabled by default]
     volatile uint32_t *port = &(PORT->Group[p.ulPort].IN.reg);
                             ^