### PR TITLE
platform: Add USB device MaxPower default setting

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -73,7 +73,10 @@ compiler.arm.cmsis.ldflags="-L{runtime.tools.CMSIS-4.5.0.path}/CMSIS/Lib/GCC/"  
 
 # USB Flags
 # ---------
-build.usb_flags=-DUSB_VID={build.vid} -DUSB_PID={build.pid} -DUSBCON '-DUSB_MANUFACTURER={build.usb_manufacturer}' '-DUSB_PRODUCT={build.usb_product}' {build.flags.usbstack} {build.flags.debug} "-I{build.core.path}/Adafruit_TinyUSB_Core" "-I{build.core.path}/Adafruit_TinyUSB_Core/tinyusb/src"
+build.usb_flags=-DUSB_VID={build.vid} -DUSB_PID={build.pid} -DUSBCON -DUSB_CONFIG_POWER={build.usb_power} '-DUSB_MANUFACTURER={build.usb_manufacturer}' '-DUSB_PRODUCT={build.usb_product}' {build.flags.usbstack} {build.flags.debug} "-I{build.core.path}/Adafruit_TinyUSB_Core" "-I{build.core.path}/Adafruit_TinyUSB_Core/tinyusb/src"
+
+# Default advertised device power setting in mA
+build.usb_power=100
 
 # Default usb manufacturer will be replaced at compile time using
 # numeric vendor ID if available or by board's specific value.


### PR DESCRIPTION
The MaxPower field specifies the maximum power that a device can
draw from the host, when the device is bus-powered.

Define the default value of 100mA default in the platform to
allow to override it from the board definition.

Some mobile devices will only supply 20mA. If a device is known to
draw less current, adding this to the board config will make it work:
  <boardname>.build.usb_power=20