### PR TITLE
tinyusb: Allow to replace the built-in descriptor buffer

### DIFF
--- a/cores/arduino/Adafruit_TinyUSB_Core/Adafruit_USBD_Device.cpp
+++ b/cores/arduino/Adafruit_TinyUSB_Core/Adafruit_USBD_Device.cpp
@@ -83,8 +83,9 @@ Adafruit_USBD_Device::Adafruit_USBD_Device(void)
     .bMaxPower           = TUSB_DESC_CONFIG_POWER_MA(USB_CONFIG_POWER)
   };
 
-  memcpy(_desc_cfg, &dev_cfg, sizeof(tusb_desc_configuration_t));
-
+  memcpy(_desc_cfg_buffer, &dev_cfg, sizeof(tusb_desc_configuration_t));
+  _desc_cfg = _desc_cfg_buffer;
+  _desc_cfg_size = sizeof(_desc_cfg_buffer);
   _desc_cfglen = sizeof(tusb_desc_configuration_t);
   _itf_count = 0;
   _epin_count = _epout_count = 1;
@@ -96,7 +97,7 @@ Adafruit_USBD_Device::Adafruit_USBD_Device(void)
 bool Adafruit_USBD_Device::addInterface(Adafruit_USBD_Interface& itf)
 {
   uint8_t* desc = _desc_cfg+_desc_cfglen;
-  uint16_t const len = itf.getDescriptor(_itf_count, desc, sizeof(_desc_cfg)-_desc_cfglen);
+  uint16_t const len = itf.getDescriptor(_itf_count, desc, _desc_cfg_size-_desc_cfglen);
   uint8_t* desc_end = desc+len;
 
   if ( !len ) return false;
@@ -125,6 +126,16 @@ bool Adafruit_USBD_Device::addInterface(Adafruit_USBD_Interface& itf)
   config->bNumInterfaces = _itf_count;
 
   return true;
+}
+
+void Adafruit_USBD_Device::setDescriptorBuffer(uint8_t* buf, uint32_t buflen)
+{
+  if (buflen < _desc_cfg_size)
+    return;
+
+  memcpy(buf, _desc_cfg, _desc_cfglen);
+  _desc_cfg = buf;
+  _desc_cfg_size = buflen;
 }
 
 void Adafruit_USBD_Device::setID(uint16_t vid, uint16_t pid)

--- a/cores/arduino/Adafruit_TinyUSB_Core/Adafruit_USBD_Device.h
+++ b/cores/arduino/Adafruit_TinyUSB_Core/Adafruit_USBD_Device.h
@@ -38,8 +38,10 @@ class Adafruit_USBD_Device
   private:
     tusb_desc_device_t _desc_device;
 
-    uint8_t  _desc_cfg[256];
+    uint8_t  *_desc_cfg;
+    uint16_t _desc_cfg_size;
     uint16_t _desc_cfglen;
+    uint8_t  _desc_cfg_buffer[256];
 
     uint8_t  _itf_count;
 
@@ -50,6 +52,7 @@ class Adafruit_USBD_Device
     Adafruit_USBD_Device(void);
 
     bool addInterface(Adafruit_USBD_Interface& itf);
+    void setDescriptorBuffer(uint8_t* buf, uint32_t buflen);
 
     void setID(uint16_t vid, uint16_t pid);
     void setVersion(uint16_t bcd);


### PR DESCRIPTION
Huge USB configurations might need more than 256 bytes for the
config descriptor buffer. MIDI devices with 16 virtual ports
grow the descriptor to 600+ bytes.

This call replaces the built-in buffer with the supllied buffer. The
call copies the content of the old buffer to the new buffer:

  uint8_t buf[1024];
  USBDevice.setDescriptorBuffer(buf, sizeof(buf));