### PR TITLE
SAMD51 I2C slave support for Wire library and SAMD51 viariants.

### DIFF
--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -284,7 +284,9 @@ void TwoWire::onService(void)
   #endif // PERIPH_WIRE
   TwoWire Wire(&PERIPH_WIRE, PIN_WIRE_SDA, PIN_WIRE_SCL);
 
-  void WIRE_IT_HANDLER(void) { Wire.onService(); }
+  void WIRE_IT_HANDLER(void) {
+    Wire.onService();
+  }
 
   #if defined(__SAMD51__)
     void WIRE_IT_HANDLER_0(void) { Wire.onService(); }
@@ -297,7 +299,9 @@ void TwoWire::onService(void)
 #if WIRE_INTERFACES_COUNT > 1
   TwoWire Wire1(&PERIPH_WIRE1, PIN_WIRE1_SDA, PIN_WIRE1_SCL);
 
-  void WIRE1_IT_HANDLER(void) { Wire1.onService(); }
+  void WIRE1_IT_HANDLER(void) {
+    Wire1.onService();
+  }
 
   #if defined(__SAMD51__)
     void WIRE1_IT_HANDLER_0(void) { Wire1.onService(); }
@@ -310,7 +314,9 @@ void TwoWire::onService(void)
 #if WIRE_INTERFACES_COUNT > 2
   TwoWire Wire2(&PERIPH_WIRE2, PIN_WIRE2_SDA, PIN_WIRE2_SCL);
 
-  void WIRE2_IT_HANDLER(void) { Wire2.onService(); }
+  void WIRE2_IT_HANDLER(void) {
+    Wire2.onService();
+  }
 
   #if defined(__SAMD51__)
     void WIRE2_IT_HANDLER_0(void) { Wire2.onService(); }
@@ -323,7 +329,9 @@ void TwoWire::onService(void)
 #if WIRE_INTERFACES_COUNT > 3
   TwoWire Wire3(&PERIPH_WIRE3, PIN_WIRE3_SDA, PIN_WIRE3_SCL);
 
-  void WIRE3_IT_HANDLER(void) { Wire3.onService(); }
+  void WIRE3_IT_HANDLER(void) {
+    Wire3.onService();
+  }
 
   #if defined(__SAMD51__)
     void WIRE3_IT_HANDLER_0(void) { Wire3.onService(); }
@@ -336,7 +344,9 @@ void TwoWire::onService(void)
 #if WIRE_INTERFACES_COUNT > 4
   TwoWire Wire4(&PERIPH_WIRE4, PIN_WIRE4_SDA, PIN_WIRE4_SCL);
 
-  void WIRE4_IT_HANDLER(void) { Wire4.onService(); }
+  void WIRE4_IT_HANDLER(void) {
+    Wire4.onService();
+  }
 
   #if defined(__SAMD51__)
     void WIRE4_IT_HANDLER_0(void) { Wire4.onService(); }
@@ -349,7 +359,9 @@ void TwoWire::onService(void)
 #if WIRE_INTERFACES_COUNT > 5
   TwoWire Wire5(&PERIPH_WIRE5, PIN_WIRE5_SDA, PIN_WIRE5_SCL);
 
-  void WIRE5_IT_HANDLER(void) { Wire5.onService(); }
+  void WIRE5_IT_HANDLER(void) {
+    Wire5.onService();
+  }
 
   #if defined(__SAMD51__)
     void WIRE5_IT_HANDLER_0(void) { Wire5.onService(); }

--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -284,48 +284,78 @@ void TwoWire::onService(void)
   #endif // PERIPH_WIRE
   TwoWire Wire(&PERIPH_WIRE, PIN_WIRE_SDA, PIN_WIRE_SCL);
 
-  void WIRE_IT_HANDLER(void) {
-    Wire.onService();
-  }
+  void WIRE_IT_HANDLER(void) { Wire.onService(); }
+
+  #if defined(__SAMD51__)
+    void WIRE_IT_HANDLER_0(void) { Wire.onService(); }
+    void WIRE_IT_HANDLER_1(void) { Wire.onService(); }
+    void WIRE_IT_HANDLER_2(void) { Wire.onService(); }
+    void WIRE_IT_HANDLER_3(void) { Wire.onService(); }
+  #endif // __SAMD51__
 #endif
 
 #if WIRE_INTERFACES_COUNT > 1
   TwoWire Wire1(&PERIPH_WIRE1, PIN_WIRE1_SDA, PIN_WIRE1_SCL);
 
-  void WIRE1_IT_HANDLER(void) {
-    Wire1.onService();
-  }
+  void WIRE1_IT_HANDLER(void) { Wire1.onService(); }
+
+  #if defined(__SAMD51__)
+    void WIRE1_IT_HANDLER_0(void) { Wire1.onService(); }
+    void WIRE1_IT_HANDLER_1(void) { Wire1.onService(); }
+    void WIRE1_IT_HANDLER_2(void) { Wire1.onService(); }
+    void WIRE1_IT_HANDLER_3(void) { Wire1.onService(); }
+  #endif // __SAMD51__
 #endif
 
 #if WIRE_INTERFACES_COUNT > 2
   TwoWire Wire2(&PERIPH_WIRE2, PIN_WIRE2_SDA, PIN_WIRE2_SCL);
 
-  void WIRE2_IT_HANDLER(void) {
-    Wire2.onService();
-  }
+  void WIRE2_IT_HANDLER(void) { Wire2.onService(); }
+
+  #if defined(__SAMD51__)
+    void WIRE2_IT_HANDLER_0(void) { Wire2.onService(); }
+    void WIRE2_IT_HANDLER_1(void) { Wire2.onService(); }
+    void WIRE2_IT_HANDLER_2(void) { Wire2.onService(); }
+    void WIRE2_IT_HANDLER_3(void) { Wire2.onService(); }
+  #endif // __SAMD51__
 #endif
 
 #if WIRE_INTERFACES_COUNT > 3
   TwoWire Wire3(&PERIPH_WIRE3, PIN_WIRE3_SDA, PIN_WIRE3_SCL);
 
-  void WIRE3_IT_HANDLER(void) {
-    Wire3.onService();
-  }
+  void WIRE3_IT_HANDLER(void) { Wire3.onService(); }
+
+  #if defined(__SAMD51__)
+    void WIRE3_IT_HANDLER_0(void) { Wire3.onService(); }
+    void WIRE3_IT_HANDLER_1(void) { Wire3.onService(); }
+    void WIRE3_IT_HANDLER_2(void) { Wire3.onService(); }
+    void WIRE3_IT_HANDLER_3(void) { Wire3.onService(); }
+  #endif // __SAMD51__
 #endif
 
 #if WIRE_INTERFACES_COUNT > 4
   TwoWire Wire4(&PERIPH_WIRE4, PIN_WIRE4_SDA, PIN_WIRE4_SCL);
 
-  void WIRE4_IT_HANDLER(void) {
-    Wire4.onService();
-  }
+  void WIRE4_IT_HANDLER(void) { Wire4.onService(); }
+
+  #if defined(__SAMD51__)
+    void WIRE4_IT_HANDLER_0(void) { Wire4.onService(); }
+    void WIRE4_IT_HANDLER_1(void) { Wire4.onService(); }
+    void WIRE4_IT_HANDLER_2(void) { Wire4.onService(); }
+    void WIRE4_IT_HANDLER_3(void) { Wire4.onService(); }
+  #endif // __SAMD51__
 #endif
 
 #if WIRE_INTERFACES_COUNT > 5
   TwoWire Wire5(&PERIPH_WIRE5, PIN_WIRE5_SDA, PIN_WIRE5_SCL);
 
-  void WIRE5_IT_HANDLER(void) {
-    Wire5.onService();
-  }
+  void WIRE5_IT_HANDLER(void) { Wire5.onService(); }
+
+  #if defined(__SAMD51__)
+    void WIRE5_IT_HANDLER_0(void) { Wire5.onService(); }
+    void WIRE5_IT_HANDLER_1(void) { Wire5.onService(); }
+    void WIRE5_IT_HANDLER_2(void) { Wire5.onService(); }
+    void WIRE5_IT_HANDLER_3(void) { Wire5.onService(); }
+  #endif // __SAMD51__
 #endif
 

--- a/variants/feather_m4/variant.h
+++ b/variants/feather_m4/variant.h
@@ -157,6 +157,10 @@ static const uint8_t SCK  = PIN_SPI_SCK ;
 #define PIN_WIRE_SCL         (22u)
 #define PERIPH_WIRE          sercom2
 #define WIRE_IT_HANDLER      SERCOM2_Handler
+#define WIRE_IT_HANDLER_0    SERCOM2_0_Handler
+#define WIRE_IT_HANDLER_1    SERCOM2_1_Handler
+#define WIRE_IT_HANDLER_2    SERCOM2_2_Handler
+#define WIRE_IT_HANDLER_3    SERCOM2_3_Handler
 
 static const uint8_t SDA = PIN_WIRE_SDA;
 static const uint8_t SCL = PIN_WIRE_SCL;

--- a/variants/grand_central_m4/variant.h
+++ b/variants/grand_central_m4/variant.h
@@ -217,6 +217,10 @@ static const uint8_t SCK1  = PIN_SPI1_SCK;
 #define PIN_WIRE_SCL        (63)
 #define PERIPH_WIRE         sercom3
 #define WIRE_IT_HANDLER     SERCOM3_Handler
+#define WIRE_IT_HANDLER_0   SERCOM3_0_Handler
+#define WIRE_IT_HANDLER_1   SERCOM3_1_Handler
+#define WIRE_IT_HANDLER_2   SERCOM3_2_Handler
+#define WIRE_IT_HANDLER_3   SERCOM3_3_Handler
 
 static const uint8_t SDA = PIN_WIRE_SDA;
 static const uint8_t SCL = PIN_WIRE_SCL;
@@ -225,6 +229,10 @@ static const uint8_t SCL = PIN_WIRE_SCL;
 #define PIN_WIRE1_SCL       (24)
 #define PERIPH_WIRE1        sercom6
 #define WIRE1_IT_HANDLER    SERCOM6_Handler
+#define WIRE1_IT_HANDLER_0  SERCOM6_0_Handler
+#define WIRE1_IT_HANDLER_1  SERCOM6_1_Handler
+#define WIRE1_IT_HANDLER_2  SERCOM6_2_Handler
+#define WIRE1_IT_HANDLER_3  SERCOM6_3_Handler
 
 static const uint8_t SDA1 = PIN_WIRE1_SDA;
 static const uint8_t SCL1 = PIN_WIRE1_SCL;
@@ -331,4 +339,4 @@ extern Uart Serial1;
 #define SERIAL_PORT_HARDWARE        Serial1
 #define SERIAL_PORT_HARDWARE_OPEN   Serial1
 
-#endif /* _VARIANT_METRO_M4_ */
+#endif /* _VARIANT_GRAND_CENTRAL_M4_ */

--- a/variants/hallowing_m4/variant.h
+++ b/variants/hallowing_m4/variant.h
@@ -167,6 +167,10 @@ static const uint8_t SCK1   = PIN_SPI1_SCK ;
 #define PIN_WIRE_SCL         (25u)
 #define PERIPH_WIRE          sercom2
 #define WIRE_IT_HANDLER      SERCOM2_Handler
+#define WIRE_IT_HANDLER_0    SERCOM2_0_Handler
+#define WIRE_IT_HANDLER_1    SERCOM2_1_Handler
+#define WIRE_IT_HANDLER_2    SERCOM2_2_Handler
+#define WIRE_IT_HANDLER_3    SERCOM2_3_Handler
 
 static const uint8_t SDA = PIN_WIRE_SDA;
 static const uint8_t SCL = PIN_WIRE_SCL;

--- a/variants/itsybitsy_m4/variant.h
+++ b/variants/itsybitsy_m4/variant.h
@@ -151,6 +151,10 @@ static const uint8_t SCK  = PIN_SPI_SCK ;
 #define PIN_WIRE_SCL         (22u)
 #define PERIPH_WIRE          sercom2
 #define WIRE_IT_HANDLER      SERCOM2_Handler
+#define WIRE_IT_HANDLER_0    SERCOM2_0_Handler
+#define WIRE_IT_HANDLER_1    SERCOM2_1_Handler
+#define WIRE_IT_HANDLER_2    SERCOM2_2_Handler
+#define WIRE_IT_HANDLER_3    SERCOM2_3_Handler
 
 static const uint8_t SDA = PIN_WIRE_SDA;
 static const uint8_t SCL = PIN_WIRE_SCL;
@@ -244,5 +248,5 @@ extern Uart Serial1;
 #define SERIAL_PORT_HARDWARE        Serial1
 #define SERIAL_PORT_HARDWARE_OPEN   Serial1
 
-#endif /* _VARIANT_MERTO_M4_ */
+#endif /* _VARIANT_ITSYBITSY_M4_ */
 

--- a/variants/metro_m4/variant.h
+++ b/variants/metro_m4/variant.h
@@ -159,6 +159,10 @@ static const uint8_t SCK  = PIN_SPI_SCK ;
 #define PIN_WIRE_SCL         (23u)
 #define PERIPH_WIRE          sercom5
 #define WIRE_IT_HANDLER      SERCOM5_Handler
+#define WIRE_IT_HANDLER_0    SERCOM5_0_Handler
+#define WIRE_IT_HANDLER_1    SERCOM5_1_Handler
+#define WIRE_IT_HANDLER_2    SERCOM5_2_Handler
+#define WIRE_IT_HANDLER_3    SERCOM5_3_Handler
 
 static const uint8_t SDA = PIN_WIRE_SDA;
 static const uint8_t SCL = PIN_WIRE_SCL;

--- a/variants/metro_m4_airlift/variant.h
+++ b/variants/metro_m4_airlift/variant.h
@@ -176,6 +176,10 @@ static const uint8_t SCK  = PIN_SPI_SCK ;
 #define PIN_WIRE_SCL         (23u)
 #define PERIPH_WIRE          sercom5
 #define WIRE_IT_HANDLER      SERCOM5_Handler
+#define WIRE_IT_HANDLER_0    SERCOM5_0_Handler
+#define WIRE_IT_HANDLER_1    SERCOM5_1_Handler
+#define WIRE_IT_HANDLER_2    SERCOM5_2_Handler
+#define WIRE_IT_HANDLER_3    SERCOM5_3_Handler
 
 static const uint8_t SDA = PIN_WIRE_SDA;
 static const uint8_t SCL = PIN_WIRE_SCL;

--- a/variants/pybadge_airlift_m4/variant.h
+++ b/variants/pybadge_airlift_m4/variant.h
@@ -264,5 +264,5 @@ extern Uart Serial1;
 #define SERIAL_PORT_HARDWARE        Serial1
 #define SERIAL_PORT_HARDWARE_OPEN   Serial1
 
-#endif /* _VARIANT_FEATHER_M4_ */
+#endif /* _VARIANT_PYBADGE_AIRLIFT_M4_ */
 

--- a/variants/pybadge_airlift_m4/variant.h
+++ b/variants/pybadge_airlift_m4/variant.h
@@ -184,6 +184,10 @@ static const uint8_t SCK1 = PIN_SPI1_SCK ;
 #define PIN_WIRE_SCL         (25u)
 #define PERIPH_WIRE          sercom2
 #define WIRE_IT_HANDLER      SERCOM2_Handler
+#define WIRE_IT_HANDLER_0    SERCOM2_0_Handler
+#define WIRE_IT_HANDLER_1    SERCOM2_1_Handler
+#define WIRE_IT_HANDLER_2    SERCOM2_2_Handler
+#define WIRE_IT_HANDLER_3    SERCOM2_3_Handler
 
 static const uint8_t SDA = PIN_WIRE_SDA;
 static const uint8_t SCL = PIN_WIRE_SCL;

--- a/variants/pybadge_m4/variant.h
+++ b/variants/pybadge_m4/variant.h
@@ -185,6 +185,10 @@ static const uint8_t SCK2 = PIN_SPI2_SCK ;
 #define PIN_WIRE_SCL         (25u)
 #define PERIPH_WIRE          sercom2
 #define WIRE_IT_HANDLER      SERCOM2_Handler
+#define WIRE_IT_HANDLER_0    SERCOM2_0_Handler
+#define WIRE_IT_HANDLER_1    SERCOM2_1_Handler
+#define WIRE_IT_HANDLER_2    SERCOM2_2_Handler
+#define WIRE_IT_HANDLER_3    SERCOM2_3_Handler
 
 static const uint8_t SDA = PIN_WIRE_SDA;
 static const uint8_t SCL = PIN_WIRE_SCL;
@@ -261,5 +265,5 @@ extern Uart Serial1;
 #define SERIAL_PORT_HARDWARE        Serial1
 #define SERIAL_PORT_HARDWARE_OPEN   Serial1
 
-#endif /* _VARIANT_FEATHER_M4_ */
+#endif /* _VARIANT_PYBADGE_M4_ */
 

--- a/variants/pygamer_advance_m4/variant.h
+++ b/variants/pygamer_advance_m4/variant.h
@@ -176,6 +176,10 @@ static const uint8_t SCK1 = PIN_SPI1_SCK ;
 #define PIN_WIRE_SCL         (27u)
 #define PERIPH_WIRE          sercom2
 #define WIRE_IT_HANDLER      SERCOM2_Handler
+#define WIRE_IT_HANDLER_0    SERCOM2_0_Handler
+#define WIRE_IT_HANDLER_1    SERCOM2_1_Handler
+#define WIRE_IT_HANDLER_2    SERCOM2_2_Handler
+#define WIRE_IT_HANDLER_3    SERCOM2_3_Handler
 
 static const uint8_t SDA = PIN_WIRE_SDA;
 static const uint8_t SCL = PIN_WIRE_SCL;

--- a/variants/pygamer_m4/variant.h
+++ b/variants/pygamer_m4/variant.h
@@ -176,6 +176,10 @@ static const uint8_t SCK1 = PIN_SPI1_SCK ;
 #define PIN_WIRE_SCL         (27u)
 #define PERIPH_WIRE          sercom2
 #define WIRE_IT_HANDLER      SERCOM2_Handler
+#define WIRE_IT_HANDLER_0    SERCOM2_0_Handler
+#define WIRE_IT_HANDLER_1    SERCOM2_1_Handler
+#define WIRE_IT_HANDLER_2    SERCOM2_2_Handler
+#define WIRE_IT_HANDLER_3    SERCOM2_3_Handler
 
 static const uint8_t SDA = PIN_WIRE_SDA;
 static const uint8_t SCL = PIN_WIRE_SCL;

--- a/variants/pygamer_m4/variant.h
+++ b/variants/pygamer_m4/variant.h
@@ -256,5 +256,5 @@ extern Uart Serial1;
 #define SERIAL_PORT_HARDWARE        Serial1
 #define SERIAL_PORT_HARDWARE_OPEN   Serial1
 
-#endif /* _VARIANT_FEATHER_M4_ */
+#endif /* _VARIANT_PYGAMER_M4_ */
 

--- a/variants/pyportal_m4/variant.h
+++ b/variants/pyportal_m4/variant.h
@@ -175,6 +175,11 @@ static const uint8_t SCK  = PIN_SPI_SCK;
 #define PIN_WIRE_SCL         (28u)
 #define PERIPH_WIRE          sercom5
 #define WIRE_IT_HANDLER      SERCOM5_Handler
+#define WIRE_IT_HANDLER_0    SERCOM5_0_Handler
+#define WIRE_IT_HANDLER_1    SERCOM5_1_Handler
+#define WIRE_IT_HANDLER_2    SERCOM5_2_Handler
+#define WIRE_IT_HANDLER_3    SERCOM5_3_Handler
+
 
 static const uint8_t SDA = PIN_WIRE_SDA;
 static const uint8_t SCL = PIN_WIRE_SCL;
@@ -245,5 +250,5 @@ extern Uart Serial1;
 #define SERIAL_PORT_HARDWARE        Serial1
 #define SERIAL_PORT_HARDWARE_OPEN   Serial1
 
-#endif /* _VARIANT_METRO_M4_ */
+#endif /* _VARIANT_PYPORTAL_M4_ */
 

--- a/variants/pyportal_m4_titano/variant.h
+++ b/variants/pyportal_m4_titano/variant.h
@@ -175,6 +175,10 @@ static const uint8_t SCK  = PIN_SPI_SCK;
 #define PIN_WIRE_SCL         (28u)
 #define PERIPH_WIRE          sercom5
 #define WIRE_IT_HANDLER      SERCOM5_Handler
+#define WIRE_IT_HANDLER_0    SERCOM5_0_Handler
+#define WIRE_IT_HANDLER_1    SERCOM5_1_Handler
+#define WIRE_IT_HANDLER_2    SERCOM5_2_Handler
+#define WIRE_IT_HANDLER_3    SERCOM5_3_Handler
 
 static const uint8_t SDA = PIN_WIRE_SDA;
 static const uint8_t SCL = PIN_WIRE_SCL;
@@ -245,5 +249,5 @@ extern Uart Serial1;
 #define SERIAL_PORT_HARDWARE        Serial1
 #define SERIAL_PORT_HARDWARE_OPEN   Serial1
 
-#endif /* _VARIANT_METRO_M4_ */
+#endif /* _VARIANT_PYPORTAL_M4_TITANO_ */
 

--- a/variants/trellis_m4/variant.cpp
+++ b/variants/trellis_m4/variant.cpp
@@ -110,22 +110,21 @@ SERCOM sercom3( SERCOM3 ) ;
 SERCOM sercom4( SERCOM4 ) ;
 SERCOM sercom5( SERCOM5 ) ;
 
-// TODO resolve SERCOM4_X_Handler conflict w/ I2C Wire
-// Uart Serial1( &sercom4, PIN_SERIAL1_RX, PIN_SERIAL1_TX, PAD_SERIAL1_RX, PAD_SERIAL1_TX ) ;
+Uart Serial1( &sercom4, PIN_SERIAL1_RX, PIN_SERIAL1_TX, PAD_SERIAL1_RX, PAD_SERIAL1_TX ) ;
 
-// void SERCOM4_0_Handler()
-// {
-//   Serial1.IrqHandler();
-// }
-// void SERCOM4_1_Handler()
-// {
-//   Serial1.IrqHandler();
-// }
-// void SERCOM4_2_Handler()
-// {
-//   Serial1.IrqHandler();
-// }
-// void SERCOM4_3_Handler()
-// {
-//   Serial1.IrqHandler();
-// }
+void SERCOM4_0_Handler()
+{
+  Serial1.IrqHandler();
+}
+void SERCOM4_1_Handler()
+{
+  Serial1.IrqHandler();
+}
+void SERCOM4_2_Handler()
+{
+  Serial1.IrqHandler();
+}
+void SERCOM4_3_Handler()
+{
+  Serial1.IrqHandler();
+}

--- a/variants/trellis_m4/variant.cpp
+++ b/variants/trellis_m4/variant.cpp
@@ -110,21 +110,22 @@ SERCOM sercom3( SERCOM3 ) ;
 SERCOM sercom4( SERCOM4 ) ;
 SERCOM sercom5( SERCOM5 ) ;
 
-Uart Serial1( &sercom4, PIN_SERIAL1_RX, PIN_SERIAL1_TX, PAD_SERIAL1_RX, PAD_SERIAL1_TX ) ;
+// TODO resolve SERCOM4_X_Handler conflict w/ I2C Wire
+// Uart Serial1( &sercom4, PIN_SERIAL1_RX, PIN_SERIAL1_TX, PAD_SERIAL1_RX, PAD_SERIAL1_TX ) ;
 
-void SERCOM4_0_Handler()
-{
-  Serial1.IrqHandler();
-}
-void SERCOM4_1_Handler()
-{
-  Serial1.IrqHandler();
-}
-void SERCOM4_2_Handler()
-{
-  Serial1.IrqHandler();
-}
-void SERCOM4_3_Handler()
-{
-  Serial1.IrqHandler();
-}
+// void SERCOM4_0_Handler()
+// {
+//   Serial1.IrqHandler();
+// }
+// void SERCOM4_1_Handler()
+// {
+//   Serial1.IrqHandler();
+// }
+// void SERCOM4_2_Handler()
+// {
+//   Serial1.IrqHandler();
+// }
+// void SERCOM4_3_Handler()
+// {
+//   Serial1.IrqHandler();
+// }

--- a/variants/trellis_m4/variant.h
+++ b/variants/trellis_m4/variant.h
@@ -156,6 +156,10 @@ static const uint8_t SCK  = PIN_SPI_SCK ;
 #define PIN_WIRE_SCL         (22u)
 #define PERIPH_WIRE          sercom4
 #define WIRE_IT_HANDLER      SERCOM4_Handler
+#define WIRE_IT_HANDLER_0    SERCOM4_0_Handler
+#define WIRE_IT_HANDLER_1    SERCOM4_1_Handler
+#define WIRE_IT_HANDLER_2    SERCOM4_2_Handler
+#define WIRE_IT_HANDLER_3    SERCOM4_3_Handler
 static const uint8_t SDA = PIN_WIRE_SDA;
 static const uint8_t SCL = PIN_WIRE_SCL;
 
@@ -164,6 +168,11 @@ static const uint8_t SCL = PIN_WIRE_SCL;
 #define PIN_WIRE1_SCL         (1u)
 #define PERIPH_WIRE1          sercom2
 #define WIRE1_IT_HANDLER      SERCOM2_Handler
+#define WIRE1_IT_HANDLER_0    SERCOM2_0_Handler
+#define WIRE1_IT_HANDLER_1    SERCOM2_1_Handler
+#define WIRE1_IT_HANDLER_2    SERCOM2_2_Handler
+#define WIRE1_IT_HANDLER_3    SERCOM2_3_Handler
+
 static const uint8_t SDA1 = PIN_WIRE_SDA;
 static const uint8_t SCL1 = PIN_WIRE_SCL;
 
@@ -241,5 +250,5 @@ extern Uart Serial1;
 #define SERIAL_PORT_HARDWARE_OPEN   Serial1
 
 
-#endif /* _VARIANT_MERTO_M4_ */
+#endif /* _VARIANT_TRELLIS_M4_ */
 

--- a/variants/trellis_m4/variant.h
+++ b/variants/trellis_m4/variant.h
@@ -156,10 +156,13 @@ static const uint8_t SCK  = PIN_SPI_SCK ;
 #define PIN_WIRE_SCL         (22u)
 #define PERIPH_WIRE          sercom4
 #define WIRE_IT_HANDLER      SERCOM4_Handler
-#define WIRE_IT_HANDLER_0    SERCOM4_0_Handler
-#define WIRE_IT_HANDLER_1    SERCOM4_1_Handler
-#define WIRE_IT_HANDLER_2    SERCOM4_2_Handler
-#define WIRE_IT_HANDLER_3    SERCOM4_3_Handler
+
+// Sercom interrupt handlers for I2C slave not set; they are used by Serial1
+// #define WIRE_IT_HANDLER_0    SERCOM4_0_Handler
+// #define WIRE_IT_HANDLER_1    SERCOM4_1_Handler
+// #define WIRE_IT_HANDLER_2    SERCOM4_2_Handler
+// #define WIRE_IT_HANDLER_3    SERCOM4_3_Handler
+
 static const uint8_t SDA = PIN_WIRE_SDA;
 static const uint8_t SCL = PIN_WIRE_SCL;
 


### PR DESCRIPTION
Fixes #45 by adding handlers for all for SAMD51 SERCOM I2C interrupts to `wire.cpp` and defining them  in the appropriate `variant.h`.

This is opened as a draft, because the M4 Trellis has a conflict as it already defined handlers for SERCOM4 for use with UART `Serial1` in its `variants.cpp`. I'm looking for advice on how to best resolve this.
