### PR TITLE
SAMD21: Fix freq clipping in SPI.h, allow 24 MHz SPI

### DIFF
--- a/libraries/SPI/SPI.h
+++ b/libraries/SPI/SPI.h
@@ -52,9 +52,11 @@
   // The datasheet specifies a typical SPI SCK period (tSCK) of 42 ns,
   // see "Table 36-48. SPI Timing Characteristics and Requirements",
   // which translates into a maximum SPI clock of 23.8 MHz.
-  // Conservatively, the divider is set for a 12 MHz maximum SPI clock.
+  // We'll permit use of 24 MHz SPI even though this is slightly out
+  // of spec. Given how clock dividers work, the next "sensible"
+  // threshold would be a substantial drop down to 12 MHz.
   #if !defined(MAX_SPI)
-    #define MAX_SPI 12000000
+    #define MAX_SPI 24000000
   #endif
   #define SPI_MIN_CLOCK_DIVIDER (uint8_t)(1 + ((F_CPU - 1) / MAX_SPI))
 #endif
@@ -81,7 +83,7 @@ class SPISettings {
 #if defined(__SAMD51__)
     this->clockFreq = clock; // Clipping handled in SERCOM.cpp
 #else
-    this->clockFreq = (clock >= (MAX_SPI * 2 / SPI_MIN_CLOCK_DIVIDER) ? MAX_SPI * 2 / SPI_MIN_CLOCK_DIVIDER : clock);
+    this->clockFreq = clock >= MAX_SPI ? MAX_SPI : clock;
 #endif
 
     this->bitOrder = (bitOrder == MSBFIRST ? MSB_FIRST : LSB_FIRST);


### PR DESCRIPTION
SPI clock freq previously clipped at MAX_SPI/2 (6 MHz) rather than MAX_SPI. Now works correctly.
Additionally, MAX_SPI set at 24 MHz on SAMD21. This is only slightly beyond spec and so far seems reliable with SD and SdFat tests on M0 Adalogger, eyes on HalloWing M0.