### PR TITLE
Restore DAC write resolution scaling for SAMD21 boards

### DIFF
--- a/cores/arduino/wiring_analog.c
+++ b/cores/arduino/wiring_analog.c
@@ -415,10 +415,9 @@ void analogWrite(uint32_t pin, uint32_t value)
 	    if (pin == PIN_DAC0) { // Only 1 DAC on A0 (PA02)
 #endif
 
+	    	value = mapResolution(value, _writeResolution, _dacResolution);
+
 #if defined(__SAMD51__)
-
-	    value = mapResolution(value, _writeResolution, _dacResolution);
-
 
 			uint8_t channel = (pin == PIN_DAC0 ? 0 : 1);
 


### PR DESCRIPTION
Commit c7fa463c0d5586e010eeab57220200fd9fe27a73 removed analog resolution mapping for DAC on SAMD21 boards, thereby forcing all DAC output values to be specified as 10-bit integers despite any previous attempt to change the write resolution with [analogWriteResolution](https://www.arduino.cc/reference/en/language/functions/zero-due-mkr-family/analogwriteresolution/).  This change reverts that commit.