### PR TITLE
Avoid warning: unused parameter for SERCOM::setClockSource()

### DIFF
--- a/cores/arduino/SERCOM.h
+++ b/cores/arduino/SERCOM.h
@@ -245,7 +245,7 @@ class SERCOM
 		uint32_t getFreqRef(void) { return freqRef; };
 #else
 		// The equivalent SAMD21 dummy functions...
-		void setClockSource(int8_t idx, SercomClockSource src, bool core) { };
+		void setClockSource(__attribute__((unused)) int8_t idx, __attribute__((unused)) SercomClockSource src, __attribute__((unused)) bool core) { };
 		SercomClockSource getClockSource(void) { return SERCOM_CLOCK_SOURCE_FCPU; };
 		uint32_t getFreqRef(void) { return F_CPU; };
 #endif


### PR DESCRIPTION
Adding __attribute__((unused)) to unused parameters of SERCOM::setClockSource().