### PR TITLE
Fix compile warnings

### DIFF
--- a/bootloaders/mzero/Bootloader_D21/src/ASF/sam0/utils/cmsis/samd21/include/samd21e15a.h
+++ b/bootloaders/mzero/Bootloader_D21/src/ASF/sam0/utils/cmsis/samd21/include/samd21e15a.h
@@ -218,7 +218,11 @@ void I2S_Handler                 ( void );
  * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
  */
 
-#define LITTLE_ENDIAN          1        
+#if defined(LITTLE_ENDIAN) && (LITTLE_ENDIAN != 1)
+  #error "Little Endian is already defined, but to different value than expected?!"
+#else
+  #define LITTLE_ENDIAN          1
+#endif
 #define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
 #define __MPU_PRESENT          0         /*!< MPU present or not */
 #define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */

--- a/bootloaders/mzero/Bootloader_D21/src/ASF/sam0/utils/cmsis/samd21/include/samd21e16a.h
+++ b/bootloaders/mzero/Bootloader_D21/src/ASF/sam0/utils/cmsis/samd21/include/samd21e16a.h
@@ -218,7 +218,11 @@ void I2S_Handler                 ( void );
  * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
  */
 
-#define LITTLE_ENDIAN          1        
+#if defined(LITTLE_ENDIAN) && (LITTLE_ENDIAN != 1)
+  #error "Little Endian is already defined, but to different value than expected?!"
+#else
+  #define LITTLE_ENDIAN          1
+#endif
 #define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
 #define __MPU_PRESENT          0         /*!< MPU present or not */
 #define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */

--- a/bootloaders/mzero/Bootloader_D21/src/ASF/sam0/utils/cmsis/samd21/include/samd21e17a.h
+++ b/bootloaders/mzero/Bootloader_D21/src/ASF/sam0/utils/cmsis/samd21/include/samd21e17a.h
@@ -218,7 +218,11 @@ void I2S_Handler                 ( void );
  * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
  */
 
-#define LITTLE_ENDIAN          1        
+#if defined(LITTLE_ENDIAN) && (LITTLE_ENDIAN != 1)
+  #error "Little Endian is already defined, but to different value than expected?!"
+#else
+  #define LITTLE_ENDIAN          1
+#endif
 #define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
 #define __MPU_PRESENT          0         /*!< MPU present or not */
 #define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */

--- a/bootloaders/mzero/Bootloader_D21/src/ASF/sam0/utils/cmsis/samd21/include/samd21e18a.h
+++ b/bootloaders/mzero/Bootloader_D21/src/ASF/sam0/utils/cmsis/samd21/include/samd21e18a.h
@@ -218,7 +218,11 @@ void I2S_Handler                 ( void );
  * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
  */
 
-#define LITTLE_ENDIAN          1        
+#if defined(LITTLE_ENDIAN) && (LITTLE_ENDIAN != 1)
+  #error "Little Endian is already defined, but to different value than expected?!"
+#else
+  #define LITTLE_ENDIAN          1
+#endif
 #define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
 #define __MPU_PRESENT          0         /*!< MPU present or not */
 #define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */

--- a/bootloaders/mzero/Bootloader_D21/src/ASF/sam0/utils/cmsis/samd21/include/samd21g15a.h
+++ b/bootloaders/mzero/Bootloader_D21/src/ASF/sam0/utils/cmsis/samd21/include/samd21g15a.h
@@ -222,7 +222,11 @@ void I2S_Handler                 ( void );
  * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
  */
 
-#define LITTLE_ENDIAN          1        
+#if defined(LITTLE_ENDIAN) && (LITTLE_ENDIAN != 1)
+  #error "Little Endian is already defined, but to different value than expected?!"
+#else
+  #define LITTLE_ENDIAN          1
+#endif
 #define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
 #define __MPU_PRESENT          0         /*!< MPU present or not */
 #define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */

--- a/bootloaders/mzero/Bootloader_D21/src/ASF/sam0/utils/cmsis/samd21/include/samd21g16a.h
+++ b/bootloaders/mzero/Bootloader_D21/src/ASF/sam0/utils/cmsis/samd21/include/samd21g16a.h
@@ -222,7 +222,11 @@ void I2S_Handler                 ( void );
  * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
  */
 
-#define LITTLE_ENDIAN          1        
+#if defined(LITTLE_ENDIAN) && (LITTLE_ENDIAN != 1)
+  #error "Little Endian is already defined, but to different value than expected?!"
+#else
+  #define LITTLE_ENDIAN          1
+#endif
 #define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
 #define __MPU_PRESENT          0         /*!< MPU present or not */
 #define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */

--- a/bootloaders/mzero/Bootloader_D21/src/ASF/sam0/utils/cmsis/samd21/include/samd21g17a.h
+++ b/bootloaders/mzero/Bootloader_D21/src/ASF/sam0/utils/cmsis/samd21/include/samd21g17a.h
@@ -222,7 +222,11 @@ void I2S_Handler                 ( void );
  * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
  */
 
-#define LITTLE_ENDIAN          1        
+#if defined(LITTLE_ENDIAN) && (LITTLE_ENDIAN != 1)
+  #error "Little Endian is already defined, but to different value than expected?!"
+#else
+  #define LITTLE_ENDIAN          1
+#endif
 #define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
 #define __MPU_PRESENT          0         /*!< MPU present or not */
 #define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */

--- a/bootloaders/mzero/Bootloader_D21/src/ASF/sam0/utils/cmsis/samd21/include/samd21g18a.h
+++ b/bootloaders/mzero/Bootloader_D21/src/ASF/sam0/utils/cmsis/samd21/include/samd21g18a.h
@@ -222,7 +222,11 @@ void I2S_Handler                 ( void );
  * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
  */
 
-#define LITTLE_ENDIAN          1        
+#if defined(LITTLE_ENDIAN) && (LITTLE_ENDIAN != 1)
+  #error "Little Endian is already defined, but to different value than expected?!"
+#else
+  #define LITTLE_ENDIAN          1
+#endif
 #define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
 #define __MPU_PRESENT          0         /*!< MPU present or not */
 #define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */

--- a/bootloaders/mzero/Bootloader_D21/src/ASF/sam0/utils/cmsis/samd21/include/samd21j15a.h
+++ b/bootloaders/mzero/Bootloader_D21/src/ASF/sam0/utils/cmsis/samd21/include/samd21j15a.h
@@ -226,7 +226,11 @@ void I2S_Handler                 ( void );
  * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
  */
 
-#define LITTLE_ENDIAN          1        
+#if defined(LITTLE_ENDIAN) && (LITTLE_ENDIAN != 1)
+  #error "Little Endian is already defined, but to different value than expected?!"
+#else
+  #define LITTLE_ENDIAN          1
+#endif
 #define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
 #define __MPU_PRESENT          0         /*!< MPU present or not */
 #define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */

--- a/bootloaders/mzero/Bootloader_D21/src/ASF/sam0/utils/cmsis/samd21/include/samd21j16a.h
+++ b/bootloaders/mzero/Bootloader_D21/src/ASF/sam0/utils/cmsis/samd21/include/samd21j16a.h
@@ -226,7 +226,11 @@ void I2S_Handler                 ( void );
  * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
  */
 
-#define LITTLE_ENDIAN          1        
+#if defined(LITTLE_ENDIAN) && (LITTLE_ENDIAN != 1)
+  #error "Little Endian is already defined, but to different value than expected?!"
+#else
+  #define LITTLE_ENDIAN          1
+#endif
 #define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
 #define __MPU_PRESENT          0         /*!< MPU present or not */
 #define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */

--- a/bootloaders/mzero/Bootloader_D21/src/ASF/sam0/utils/cmsis/samd21/include/samd21j17a.h
+++ b/bootloaders/mzero/Bootloader_D21/src/ASF/sam0/utils/cmsis/samd21/include/samd21j17a.h
@@ -226,7 +226,11 @@ void I2S_Handler                 ( void );
  * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
  */
 
-#define LITTLE_ENDIAN          1        
+#if defined(LITTLE_ENDIAN) && (LITTLE_ENDIAN != 1)
+  #error "Little Endian is already defined, but to different value than expected?!"
+#else
+  #define LITTLE_ENDIAN          1
+#endif
 #define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
 #define __MPU_PRESENT          0         /*!< MPU present or not */
 #define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */

--- a/bootloaders/mzero/Bootloader_D21/src/ASF/sam0/utils/cmsis/samd21/include/samd21j18a.h
+++ b/bootloaders/mzero/Bootloader_D21/src/ASF/sam0/utils/cmsis/samd21/include/samd21j18a.h
@@ -226,7 +226,11 @@ void I2S_Handler                 ( void );
  * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
  */
 
-#define LITTLE_ENDIAN          1        
+#if defined(LITTLE_ENDIAN) && (LITTLE_ENDIAN != 1)
+  #error "Little Endian is already defined, but to different value than expected?!"
+#else
+  #define LITTLE_ENDIAN          1
+#endif
 #define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
 #define __MPU_PRESENT          0         /*!< MPU present or not */
 #define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */

--- a/bootloaders/sofia/Bootloader_D21_Sofia_V2.1/src/ASF/sam0/utils/cmsis/samd21/include/samd21e15a.h
+++ b/bootloaders/sofia/Bootloader_D21_Sofia_V2.1/src/ASF/sam0/utils/cmsis/samd21/include/samd21e15a.h
@@ -218,7 +218,11 @@ void I2S_Handler                 ( void );
  * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
  */
 
-#define LITTLE_ENDIAN          1        
+#if defined(LITTLE_ENDIAN) && (LITTLE_ENDIAN != 1)
+  #error "Little Endian is already defined, but to different value than expected?!"
+#else
+  #define LITTLE_ENDIAN          1
+#endif
 #define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
 #define __MPU_PRESENT          0         /*!< MPU present or not */
 #define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */

--- a/bootloaders/sofia/Bootloader_D21_Sofia_V2.1/src/ASF/sam0/utils/cmsis/samd21/include/samd21e16a.h
+++ b/bootloaders/sofia/Bootloader_D21_Sofia_V2.1/src/ASF/sam0/utils/cmsis/samd21/include/samd21e16a.h
@@ -218,7 +218,11 @@ void I2S_Handler                 ( void );
  * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
  */
 
-#define LITTLE_ENDIAN          1        
+#if defined(LITTLE_ENDIAN) && (LITTLE_ENDIAN != 1)
+  #error "Little Endian is already defined, but to different value than expected?!"
+#else
+  #define LITTLE_ENDIAN          1
+#endif
 #define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
 #define __MPU_PRESENT          0         /*!< MPU present or not */
 #define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */

--- a/bootloaders/sofia/Bootloader_D21_Sofia_V2.1/src/ASF/sam0/utils/cmsis/samd21/include/samd21e17a.h
+++ b/bootloaders/sofia/Bootloader_D21_Sofia_V2.1/src/ASF/sam0/utils/cmsis/samd21/include/samd21e17a.h
@@ -218,7 +218,11 @@ void I2S_Handler                 ( void );
  * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
  */
 
-#define LITTLE_ENDIAN          1        
+#if defined(LITTLE_ENDIAN) && (LITTLE_ENDIAN != 1)
+  #error "Little Endian is already defined, but to different value than expected?!"
+#else
+  #define LITTLE_ENDIAN          1
+#endif
 #define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
 #define __MPU_PRESENT          0         /*!< MPU present or not */
 #define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */

--- a/bootloaders/sofia/Bootloader_D21_Sofia_V2.1/src/ASF/sam0/utils/cmsis/samd21/include/samd21e18a.h
+++ b/bootloaders/sofia/Bootloader_D21_Sofia_V2.1/src/ASF/sam0/utils/cmsis/samd21/include/samd21e18a.h
@@ -218,7 +218,11 @@ void I2S_Handler                 ( void );
  * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
  */
 
-#define LITTLE_ENDIAN          1        
+#if defined(LITTLE_ENDIAN) && (LITTLE_ENDIAN != 1)
+  #error "Little Endian is already defined, but to different value than expected?!"
+#else
+  #define LITTLE_ENDIAN          1
+#endif
 #define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
 #define __MPU_PRESENT          0         /*!< MPU present or not */
 #define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */

--- a/bootloaders/sofia/Bootloader_D21_Sofia_V2.1/src/ASF/sam0/utils/cmsis/samd21/include/samd21g15a.h
+++ b/bootloaders/sofia/Bootloader_D21_Sofia_V2.1/src/ASF/sam0/utils/cmsis/samd21/include/samd21g15a.h
@@ -222,7 +222,11 @@ void I2S_Handler                 ( void );
  * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
  */
 
-#define LITTLE_ENDIAN          1        
+#if defined(LITTLE_ENDIAN) && (LITTLE_ENDIAN != 1)
+  #error "Little Endian is already defined, but to different value than expected?!"
+#else
+  #define LITTLE_ENDIAN          1
+#endif
 #define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
 #define __MPU_PRESENT          0         /*!< MPU present or not */
 #define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */

--- a/bootloaders/sofia/Bootloader_D21_Sofia_V2.1/src/ASF/sam0/utils/cmsis/samd21/include/samd21g16a.h
+++ b/bootloaders/sofia/Bootloader_D21_Sofia_V2.1/src/ASF/sam0/utils/cmsis/samd21/include/samd21g16a.h
@@ -222,7 +222,11 @@ void I2S_Handler                 ( void );
  * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
  */
 
-#define LITTLE_ENDIAN          1        
+#if defined(LITTLE_ENDIAN) && (LITTLE_ENDIAN != 1)
+  #error "Little Endian is already defined, but to different value than expected?!"
+#else
+  #define LITTLE_ENDIAN          1
+#endif
 #define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
 #define __MPU_PRESENT          0         /*!< MPU present or not */
 #define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */

--- a/bootloaders/sofia/Bootloader_D21_Sofia_V2.1/src/ASF/sam0/utils/cmsis/samd21/include/samd21g17a.h
+++ b/bootloaders/sofia/Bootloader_D21_Sofia_V2.1/src/ASF/sam0/utils/cmsis/samd21/include/samd21g17a.h
@@ -222,7 +222,11 @@ void I2S_Handler                 ( void );
  * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
  */
 
-#define LITTLE_ENDIAN          1        
+#if defined(LITTLE_ENDIAN) && (LITTLE_ENDIAN != 1)
+  #error "Little Endian is already defined, but to different value than expected?!"
+#else
+  #define LITTLE_ENDIAN          1
+#endif
 #define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
 #define __MPU_PRESENT          0         /*!< MPU present or not */
 #define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */

--- a/bootloaders/sofia/Bootloader_D21_Sofia_V2.1/src/ASF/sam0/utils/cmsis/samd21/include/samd21g18a.h
+++ b/bootloaders/sofia/Bootloader_D21_Sofia_V2.1/src/ASF/sam0/utils/cmsis/samd21/include/samd21g18a.h
@@ -222,7 +222,11 @@ void I2S_Handler                 ( void );
  * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
  */
 
-#define LITTLE_ENDIAN          1        
+#if defined(LITTLE_ENDIAN) && (LITTLE_ENDIAN != 1)
+  #error "Little Endian is already defined, but to different value than expected?!"
+#else
+  #define LITTLE_ENDIAN          1
+#endif
 #define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
 #define __MPU_PRESENT          0         /*!< MPU present or not */
 #define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */

--- a/bootloaders/sofia/Bootloader_D21_Sofia_V2.1/src/ASF/sam0/utils/cmsis/samd21/include/samd21j15a.h
+++ b/bootloaders/sofia/Bootloader_D21_Sofia_V2.1/src/ASF/sam0/utils/cmsis/samd21/include/samd21j15a.h
@@ -226,7 +226,11 @@ void I2S_Handler                 ( void );
  * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
  */
 
-#define LITTLE_ENDIAN          1        
+#if defined(LITTLE_ENDIAN) && (LITTLE_ENDIAN != 1)
+  #error "Little Endian is already defined, but to different value than expected?!"
+#else
+  #define LITTLE_ENDIAN          1
+#endif
 #define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
 #define __MPU_PRESENT          0         /*!< MPU present or not */
 #define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */

--- a/bootloaders/sofia/Bootloader_D21_Sofia_V2.1/src/ASF/sam0/utils/cmsis/samd21/include/samd21j16a.h
+++ b/bootloaders/sofia/Bootloader_D21_Sofia_V2.1/src/ASF/sam0/utils/cmsis/samd21/include/samd21j16a.h
@@ -226,7 +226,11 @@ void I2S_Handler                 ( void );
  * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
  */
 
-#define LITTLE_ENDIAN          1        
+#if defined(LITTLE_ENDIAN) && (LITTLE_ENDIAN != 1)
+  #error "Little Endian is already defined, but to different value than expected?!"
+#else
+  #define LITTLE_ENDIAN          1
+#endif
 #define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
 #define __MPU_PRESENT          0         /*!< MPU present or not */
 #define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */

--- a/bootloaders/sofia/Bootloader_D21_Sofia_V2.1/src/ASF/sam0/utils/cmsis/samd21/include/samd21j17a.h
+++ b/bootloaders/sofia/Bootloader_D21_Sofia_V2.1/src/ASF/sam0/utils/cmsis/samd21/include/samd21j17a.h
@@ -226,7 +226,11 @@ void I2S_Handler                 ( void );
  * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
  */
 
-#define LITTLE_ENDIAN          1        
+#if defined(LITTLE_ENDIAN) && (LITTLE_ENDIAN != 1)
+  #error "Little Endian is already defined, but to different value than expected?!"
+#else
+  #define LITTLE_ENDIAN          1
+#endif
 #define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
 #define __MPU_PRESENT          0         /*!< MPU present or not */
 #define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */

--- a/bootloaders/sofia/Bootloader_D21_Sofia_V2.1/src/ASF/sam0/utils/cmsis/samd21/include/samd21j18a.h
+++ b/bootloaders/sofia/Bootloader_D21_Sofia_V2.1/src/ASF/sam0/utils/cmsis/samd21/include/samd21j18a.h
@@ -226,7 +226,11 @@ void I2S_Handler                 ( void );
  * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
  */
 
-#define LITTLE_ENDIAN          1        
+#if defined(LITTLE_ENDIAN) && (LITTLE_ENDIAN != 1)
+  #error "Little Endian is already defined, but to different value than expected?!"
+#else
+  #define LITTLE_ENDIAN          1
+#endif
 #define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
 #define __MPU_PRESENT          0         /*!< MPU present or not */
 #define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */

--- a/cores/arduino/SERCOM.h
+++ b/cores/arduino/SERCOM.h
@@ -245,7 +245,7 @@ class SERCOM
 		uint32_t getFreqRef(void) { return freqRef; };
 #else
 		// The equivalent SAMD21 dummy functions...
-		void setClockSource(int8_t idx, SercomClockSource src, bool core) { };
+		void setClockSource(__attribute__((unused)) int8_t idx, __attribute__((unused)) SercomClockSource src, __attribute__((unused)) bool core) { };
 		SercomClockSource getClockSource(void) { return SERCOM_CLOCK_SOURCE_FCPU; };
 		uint32_t getFreqRef(void) { return F_CPU; };
 #endif

--- a/cores/arduino/USB/USBCore.cpp
+++ b/cores/arduino/USB/USBCore.cpp
@@ -877,6 +877,7 @@ bool USBDeviceClass::handleStandardSetup(USBSetup &setup)
 			sendZlp(0);
 			return true;
 		}
+		return false;
 
 	case SET_ADDRESS:
 		setAddress(setup.wValueL);


### PR DESCRIPTION
Three commits:

1. compiler now defines the symbol `LITTLE_ENDIAN` itself, causing a conflict (with at least Trinket M0).  Now if `LITTLE_ENDIAN` is already defined, verify the value is as expected; if not already defined, then define it as previously done. 

2. Parameters that aren't used should be marked as such, else compiler throws out warning.

3. Switch statement had unintentional fall-through for `SET_FEATURE` if `wValueL` was set to anything other than zero or one.
