### PR TITLE
tinyusb: MIDI - Increase buffer size

### DIFF
--- a/cores/arduino/TinyUSB/tusb_config.h
+++ b/cores/arduino/TinyUSB/tusb_config.h
@@ -79,8 +79,8 @@
 #define CFG_TUD_HID_BUFSIZE         64
 
 // MIDI FIFO size of TX and RX
-#define CFG_TUD_MIDI_RX_BUFSIZE     64
-#define CFG_TUD_MIDI_TX_BUFSIZE     64
+#define CFG_TUD_MIDI_RX_BUFSIZE     128
+#define CFG_TUD_MIDI_TX_BUFSIZE     128
 
 // Vendor FIFO size of TX and RX
 #define CFG_TUD_VENDOR_RX_BUFSIZE   64


### PR DESCRIPTION
(This is the last MIDI-related patch I have queued up, everything else should be merged now, or waiting in the devel branch.)

We only transfer new packets when 64 bytes are available in the FIFO
buffer. This increase the buffer, so we can receive the next new packet
while still processing the current one.