### PR TITLE
Fix I2C SERCOM Hang (from Arduino SAMD core)

### DIFF
--- a/cores/arduino/SERCOM.cpp
+++ b/cores/arduino/SERCOM.cpp
@@ -537,8 +537,18 @@ bool SERCOM::startTransmissionWIRE(uint8_t address, SercomWireReadWriteFlag flag
   // 7-bits address + 1-bits R/W
   address = (address << 0x1ul) | flag;
 
-  // Wait idle or owner bus mode
-   while ( !isBusIdleWIRE() && !isBusOwnerWIRE() );
+  // If another master owns the bus or the last bus owner has not properly
+  // sent a stop, return failure early. This will prevent some misbehaved
+  // devices from deadlocking here at the cost of the caller being responsible
+  // for retrying the failed transmission. See SercomWireBusState for the
+  // possible bus states.
+  if(!isBusOwnerWIRE())
+  {
+    if( isBusBusyWIRE() || (isArbLostWIRE() && !isBusIdleWIRE()) || isBusUnknownWIRE() )
+    {
+      return false;
+    }
+  }
 
   // Send start and address
   sercom->I2CM.ADDR.bit.ADDR = address;
@@ -632,6 +642,21 @@ bool SERCOM::isBusIdleWIRE( void )
 bool SERCOM::isBusOwnerWIRE( void )
 {
   return sercom->I2CM.STATUS.bit.BUSSTATE == WIRE_OWNER_STATE;
+}
+
+bool SERCOM::isBusUnknownWIRE( void )
+{
+  return sercom->I2CM.STATUS.bit.BUSSTATE == WIRE_UNKNOWN_STATE;
+}
+
+bool SERCOM::isArbLostWIRE( void )
+{
+  return sercom->I2CM.STATUS.bit.ARBLOST == 1;
+}
+
+bool SERCOM::isBusBusyWIRE( void )
+{
+  return sercom->I2CM.STATUS.bit.BUSSTATE == WIRE_BUSY_STATE;
 }
 
 bool SERCOM::isDataReadyWIRE( void )

--- a/cores/arduino/SERCOM.h
+++ b/cores/arduino/SERCOM.h
@@ -225,6 +225,9 @@ class SERCOM
 		bool isSlaveWIRE( void ) ;
 		bool isBusIdleWIRE( void ) ;
 		bool isBusOwnerWIRE( void ) ;
+		bool isBusUnknownWIRE( void ) ;
+		bool isArbLostWIRE( void );
+		bool isBusBusyWIRE( void );
 		bool isDataReadyWIRE( void ) ;
 		bool isStopDetectedWIRE( void ) ;
 		bool isRestartDetectedWIRE( void ) ;


### PR DESCRIPTION
This patch replaces an infinite loop in `SERCOM::startTransmissionWIRE` with [code from the Arduino SAMD core](https://github.com/arduino/ArduinoCore-samd/blob/46f6cad46b55aab1e6081bc1bb60e4fd66dad4c0/cores/arduino/SERCOM.cpp#L508-L514) to prevent a lockup upon I2C failure.