### PR TITLE
Update toolchain cmsis, fix build with tensorflow

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -448,7 +448,7 @@ adafruit_metro_m4.build.vid=0x239A
 adafruit_metro_m4.build.pid=0x8020
 adafruit_metro_m4.bootloader.tool=openocd
 adafruit_metro_m4.bootloader.file=metroM4/bootloader-metro_m4-v2.0.0-adafruit.5.bin
-adafruit_metro_m4.compiler.arm.cmsis.ldflags="-L{runtime.tools.CMSIS-4.5.0.path}/CMSIS/Lib/GCC/" "-L{build.variant.path}" -larm_cortexM4lf_math -mfloat-abi=hard -mfpu=fpv4-sp-d16
+adafruit_metro_m4.compiler.arm.cmsis.ldflags="-L{runtime.tools.CMSIS-5.4.0.path}/CMSIS/Lib/GCC/" "-L{build.variant.path}" -larm_cortexM4lf_math -mfloat-abi=hard -mfpu=fpv4-sp-d16
 adafruit_metro_m4.menu.cache.on=Enabled
 adafruit_metro_m4.menu.cache.on.build.cache_flags=-DENABLE_CACHE
 adafruit_metro_m4.menu.cache.off=Disabled
@@ -514,7 +514,7 @@ adafruit_grandcentral_m4.build.vid=0x239A
 adafruit_grandcentral_m4.build.pid=0x8031
 adafruit_grandcentral_m4.bootloader.tool=openocd
 adafruit_grandcentral_m4.bootloader.file=grand_central_m4/bootloader-grandcentralM4-v2.0.0-adafruit.5.bin
-adafruit_grandcentral_m4.compiler.arm.cmsis.ldflags="-L{runtime.tools.CMSIS-4.5.0.path}/CMSIS/Lib/GCC/" "-L{build.variant.path}" -larm_cortexM4lf_math -mfloat-abi=hard -mfpu=fpv4-sp-d16
+adafruit_grandcentral_m4.compiler.arm.cmsis.ldflags="-L{runtime.tools.CMSIS-5.4.0.path}/CMSIS/Lib/GCC/" "-L{build.variant.path}" -larm_cortexM4lf_math -mfloat-abi=hard -mfpu=fpv4-sp-d16
 adafruit_grandcentral_m4.menu.cache.on=Enabled
 adafruit_grandcentral_m4.menu.cache.on.build.cache_flags=-DENABLE_CACHE
 adafruit_grandcentral_m4.menu.cache.off=Disabled
@@ -577,7 +577,7 @@ adafruit_itsybitsy_m4.build.vid=0x239A
 adafruit_itsybitsy_m4.build.pid=0x802B
 adafruit_itsybitsy_m4.bootloader.tool=openocd
 adafruit_itsybitsy_m4.bootloader.file=itsybitsyM4/bootloader-itsybitsy_m4-v2.0.0-adafruit.5.bin
-adafruit_itsybitsy_m4.compiler.arm.cmsis.ldflags="-L{runtime.tools.CMSIS-4.5.0.path}/CMSIS/Lib/GCC/" "-L{build.variant.path}" -larm_cortexM4lf_math -mfloat-abi=hard -mfpu=fpv4-sp-d16
+adafruit_itsybitsy_m4.compiler.arm.cmsis.ldflags="-L{runtime.tools.CMSIS-5.4.0.path}/CMSIS/Lib/GCC/" "-L{build.variant.path}" -larm_cortexM4lf_math -mfloat-abi=hard -mfpu=fpv4-sp-d16
 adafruit_itsybitsy_m4.menu.cache.on=Enabled
 adafruit_itsybitsy_m4.menu.cache.on.build.cache_flags=-DENABLE_CACHE
 adafruit_itsybitsy_m4.menu.cache.off=Disabled
@@ -640,7 +640,7 @@ adafruit_feather_m4.build.vid=0x239A
 adafruit_feather_m4.build.pid=0x8022
 adafruit_feather_m4.bootloader.tool=openocd
 adafruit_feather_m4.bootloader.file=featherM4/bootloader-feather_m4-v2.0.0-adafruit.5.bin
-adafruit_feather_m4.compiler.arm.cmsis.ldflags="-L{runtime.tools.CMSIS-4.5.0.path}/CMSIS/Lib/GCC/" "-L{build.variant.path}" -larm_cortexM4lf_math -mfloat-abi=hard -mfpu=fpv4-sp-d16 
+adafruit_feather_m4.compiler.arm.cmsis.ldflags="-L{runtime.tools.CMSIS-5.4.0.path}/CMSIS/Lib/GCC/" "-L{build.variant.path}" -larm_cortexM4lf_math -mfloat-abi=hard -mfpu=fpv4-sp-d16 
 adafruit_feather_m4.menu.cache.on=Enabled
 adafruit_feather_m4.menu.cache.on.build.cache_flags=-DENABLE_CACHE
 adafruit_feather_m4.menu.cache.off=Disabled
@@ -705,7 +705,7 @@ adafruit_trellis_m4.build.vid=0x239A
 adafruit_trellis_m4.build.pid=0x802F
 adafruit_trellis_m4.bootloader.tool=openocd
 adafruit_trellis_m4.bootloader.file=trellisM4/bootloader-trellis_m4-v2.0.0-adafruit.5.bin
-adafruit_trellis_m4.compiler.arm.cmsis.ldflags="-L{runtime.tools.CMSIS-4.5.0.path}/CMSIS/Lib/GCC/" "-L{build.variant.path}" -larm_cortexM4lf_math -mfloat-abi=hard -mfpu=fpv4-sp-d16
+adafruit_trellis_m4.compiler.arm.cmsis.ldflags="-L{runtime.tools.CMSIS-5.4.0.path}/CMSIS/Lib/GCC/" "-L{build.variant.path}" -larm_cortexM4lf_math -mfloat-abi=hard -mfpu=fpv4-sp-d16
 adafruit_trellis_m4.menu.cache.on=Enabled
 adafruit_trellis_m4.menu.cache.on.build.cache_flags=-DENABLE_CACHE
 adafruit_trellis_m4.menu.cache.off=Disabled
@@ -768,7 +768,7 @@ adafruit_pyportal_m4.build.vid=0x239A
 adafruit_pyportal_m4.build.pid=0x8035
 adafruit_pyportal_m4.bootloader.tool=openocd
 adafruit_pyportal_m4.bootloader.file=metroM4/bootloader-metro_m4-v2.0.0-adafruit.5.bin
-adafruit_pyportal_m4.compiler.arm.cmsis.ldflags="-L{runtime.tools.CMSIS-4.5.0.path}/CMSIS/Lib/GCC/" "-L{build.variant.path}" -larm_cortexM4lf_math -mfloat-abi=hard -mfpu=fpv4-sp-d16
+adafruit_pyportal_m4.compiler.arm.cmsis.ldflags="-L{runtime.tools.CMSIS-5.4.0.path}/CMSIS/Lib/GCC/" "-L{build.variant.path}" -larm_cortexM4lf_math -mfloat-abi=hard -mfpu=fpv4-sp-d16
 adafruit_pyportal_m4.menu.cache.on=Enabled
 adafruit_pyportal_m4.menu.cache.on.build.cache_flags=-DENABLE_CACHE
 adafruit_pyportal_m4.menu.cache.off=Disabled
@@ -831,7 +831,7 @@ adafruit_pyportal_m4_titano.build.vid=0x239A
 adafruit_pyportal_m4_titano.build.pid=0x8035
 adafruit_pyportal_m4_titano.bootloader.tool=openocd
 adafruit_pyportal_m4_titano.bootloader.file=metroM4/bootloader-metro_m4-v2.0.0-adafruit.5.bin
-adafruit_pyportal_m4_titano.compiler.arm.cmsis.ldflags="-L{runtime.tools.CMSIS-4.5.0.path}/CMSIS/Lib/GCC/" "-L{build.variant.path}" -larm_cortexM4lf_math -mfloat-abi=hard -mfpu=fpv4-sp-d16
+adafruit_pyportal_m4_titano.compiler.arm.cmsis.ldflags="-L{runtime.tools.CMSIS-5.4.0.path}/CMSIS/Lib/GCC/" "-L{build.variant.path}" -larm_cortexM4lf_math -mfloat-abi=hard -mfpu=fpv4-sp-d16
 adafruit_pyportal_m4_titano.menu.cache.on=Enabled
 adafruit_pyportal_m4_titano.menu.cache.on.build.cache_flags=-DENABLE_CACHE
 adafruit_pyportal_m4_titano.menu.cache.off=Disabled
@@ -896,7 +896,7 @@ adafruit_pybadge_m4.build.vid=0x239A
 adafruit_pybadge_m4.build.pid=0x8033
 adafruit_pybadge_m4.bootloader.tool=openocd
 adafruit_pybadge_m4.bootloader.file=featherM4/bootloader-feather_m4-v2.0.0-adafruit.5.bin
-adafruit_pybadge_m4.compiler.arm.cmsis.ldflags="-L{runtime.tools.CMSIS-4.5.0.path}/CMSIS/Lib/GCC/" "-L{build.variant.path}" -larm_cortexM4lf_math -mfloat-abi=hard -mfpu=fpv4-sp-d16
+adafruit_pybadge_m4.compiler.arm.cmsis.ldflags="-L{runtime.tools.CMSIS-5.4.0.path}/CMSIS/Lib/GCC/" "-L{build.variant.path}" -larm_cortexM4lf_math -mfloat-abi=hard -mfpu=fpv4-sp-d16
 adafruit_pybadge_m4.menu.cache.on=Enabled
 adafruit_pybadge_m4.menu.cache.on.build.cache_flags=-DENABLE_CACHE
 adafruit_pybadge_m4.menu.cache.off=Disabled
@@ -960,7 +960,7 @@ adafruit_metro_m4_airliftlite.build.vid=0x239A
 adafruit_metro_m4_airliftlite.build.pid=0x8037
 adafruit_metro_m4_airliftlite.bootloader.tool=openocd
 adafruit_metro_m4_airliftlite.bootloader.file=metroM4/bootloader-metro_m4-v2.0.0-adafruit.5.bin
-adafruit_metro_m4_airliftlite.compiler.arm.cmsis.ldflags="-L{runtime.tools.CMSIS-4.5.0.path}/CMSIS/Lib/GCC/" "-L{build.variant.path}" -larm_cortexM4lf_math -mfloat-abi=hard -mfpu=fpv4-sp-d16
+adafruit_metro_m4_airliftlite.compiler.arm.cmsis.ldflags="-L{runtime.tools.CMSIS-5.4.0.path}/CMSIS/Lib/GCC/" "-L{build.variant.path}" -larm_cortexM4lf_math -mfloat-abi=hard -mfpu=fpv4-sp-d16
 adafruit_metro_m4_airliftlite.menu.cache.on=Enabled
 adafruit_metro_m4_airliftlite.menu.cache.on.build.cache_flags=-DENABLE_CACHE
 adafruit_metro_m4_airliftlite.menu.cache.off=Disabled
@@ -1025,7 +1025,7 @@ adafruit_pygamer_m4.build.vid=0x239A
 adafruit_pygamer_m4.build.pid=0x803D
 adafruit_pygamer_m4.bootloader.tool=openocd
 adafruit_pygamer_m4.bootloader.file=featherM4/bootloader-feather_m4-v2.0.0-adafruit.5.bin
-adafruit_pygamer_m4.compiler.arm.cmsis.ldflags="-L{runtime.tools.CMSIS-4.5.0.path}/CMSIS/Lib/GCC/" "-L{build.variant.path}" -larm_cortexM4lf_math -mfloat-abi=hard -mfpu=fpv4-sp-d16
+adafruit_pygamer_m4.compiler.arm.cmsis.ldflags="-L{runtime.tools.CMSIS-5.4.0.path}/CMSIS/Lib/GCC/" "-L{build.variant.path}" -larm_cortexM4lf_math -mfloat-abi=hard -mfpu=fpv4-sp-d16
 adafruit_pygamer_m4.menu.cache.on=Enabled
 adafruit_pygamer_m4.menu.cache.on.build.cache_flags=-DENABLE_CACHE
 adafruit_pygamer_m4.menu.cache.off=Disabled
@@ -1089,7 +1089,7 @@ adafruit_pygamer_advance_m4.build.vid=0x239A
 adafruit_pygamer_advance_m4.build.pid=0x8041
 adafruit_pygamer_advance_m4.bootloader.tool=openocd
 adafruit_pygamer_advance_m4.bootloader.file=featherM4/bootloader-feather_m4-v2.0.0-adafruit.5.bin
-adafruit_pygamer_advance_m4.compiler.arm.cmsis.ldflags="-L{runtime.tools.CMSIS-4.5.0.path}/CMSIS/Lib/GCC/" "-L{build.variant.path}" -larm_cortexM4lf_math -mfloat-abi=hard -mfpu=fpv4-sp-d16
+adafruit_pygamer_advance_m4.compiler.arm.cmsis.ldflags="-L{runtime.tools.CMSIS-5.4.0.path}/CMSIS/Lib/GCC/" "-L{build.variant.path}" -larm_cortexM4lf_math -mfloat-abi=hard -mfpu=fpv4-sp-d16
 adafruit_pygamer_advance_m4.menu.cache.on=Enabled
 adafruit_pygamer_advance_m4.menu.cache.on.build.cache_flags=-DENABLE_CACHE
 adafruit_pygamer_advance_m4.menu.cache.off=Disabled
@@ -1155,7 +1155,7 @@ adafruit_pybadge_airlift_m4.build.vid=0x239A
 adafruit_pybadge_airlift_m4.build.pid=0x8043
 adafruit_pybadge_airlift_m4.bootloader.tool=openocd
 adafruit_pybadge_airlift_m4.bootloader.file=featherM4/bootloader-feather_m4-v2.0.0-adafruit.5.bin
-adafruit_pybadge_airlift_m4.compiler.arm.cmsis.ldflags="-L{runtime.tools.CMSIS-4.5.0.path}/CMSIS/Lib/GCC/" "-L{build.variant.path}" -larm_cortexM4lf_math -mfloat-abi=hard -mfpu=fpv4-sp-d16
+adafruit_pybadge_airlift_m4.compiler.arm.cmsis.ldflags="-L{runtime.tools.CMSIS-5.4.0.path}/CMSIS/Lib/GCC/" "-L{build.variant.path}" -larm_cortexM4lf_math -mfloat-abi=hard -mfpu=fpv4-sp-d16
 adafruit_pybadge_airlift_m4.menu.cache.on=Enabled
 adafruit_pybadge_airlift_m4.menu.cache.on.build.cache_flags=-DENABLE_CACHE
 adafruit_pybadge_airlift_m4.menu.cache.off=Disabled
@@ -1221,7 +1221,7 @@ adafruit_monster_m4sk.build.vid=0x239A
 adafruit_monster_m4sk.build.pid=0x8047
 adafruit_monster_m4sk.bootloader.tool=openocd
 adafruit_monster_m4sk.bootloader.file=featherM4/bootloader-feather_m4-v2.0.0-adafruit.5.bin
-adafruit_monster_m4sk.compiler.arm.cmsis.ldflags="-L{runtime.tools.CMSIS-4.5.0.path}/CMSIS/Lib/GCC/" "-L{build.variant.path}" -larm_cortexM4lf_math -mfloat-abi=hard -mfpu=fpv4-sp-d16
+adafruit_monster_m4sk.compiler.arm.cmsis.ldflags="-L{runtime.tools.CMSIS-5.4.0.path}/CMSIS/Lib/GCC/" "-L{build.variant.path}" -larm_cortexM4lf_math -mfloat-abi=hard -mfpu=fpv4-sp-d16
 adafruit_monster_m4sk.menu.cache.on=Enabled
 adafruit_monster_m4sk.menu.cache.on.build.cache_flags=-DENABLE_CACHE
 adafruit_monster_m4sk.menu.cache.off=Disabled
@@ -1287,7 +1287,7 @@ adafruit_hallowing_m4.build.vid=0x239A
 adafruit_hallowing_m4.build.pid=0x8049
 adafruit_hallowing_m4.bootloader.tool=openocd
 adafruit_hallowing_m4.bootloader.file=featherM4/bootloader-feather_m4-v2.0.0-adafruit.5.bin
-adafruit_hallowing_m4.compiler.arm.cmsis.ldflags="-L{runtime.tools.CMSIS-4.5.0.path}/CMSIS/Lib/GCC/" "-L{build.variant.path}" -larm_cortexM4lf_math -mfloat-abi=hard -mfpu=fpv4-sp-d16
+adafruit_hallowing_m4.compiler.arm.cmsis.ldflags="-L{runtime.tools.CMSIS-5.4.0.path}/CMSIS/Lib/GCC/" "-L{build.variant.path}" -larm_cortexM4lf_math -mfloat-abi=hard -mfpu=fpv4-sp-d16
 adafruit_hallowing_m4.menu.cache.on=Enabled
 adafruit_hallowing_m4.menu.cache.on.build.cache_flags=-DENABLE_CACHE
 adafruit_hallowing_m4.menu.cache.off=Disabled

--- a/cores/arduino/WInterrupts.h
+++ b/cores/arduino/WInterrupts.h
@@ -31,7 +31,7 @@ extern "C" {
 #define FALLING 3
 #define RISING 4
 
-#define DEFAULT 1
+//#define DEFAULT 1
 #define EXTERNAL 0
 
 typedef void (*voidFuncPtr)(void);

--- a/platform.txt
+++ b/platform.txt
@@ -20,7 +20,7 @@
 # https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5---3rd-party-Hardware-specification
 
 name=Adafruit SAMD (32-bits ARM Cortex-M0+ and Cortex-M4) Boards
-version=1.5.14
+version=1.5.15
 
 # Compile variables
 # -----------------

--- a/platform.txt
+++ b/platform.txt
@@ -31,7 +31,7 @@ compiler.warning_flags.default=
 compiler.warning_flags.more=-Wall -Wno-expansion-to-defined
 compiler.warning_flags.all=-Wall -Wextra -Wno-expansion-to-defined
 
-compiler.path={runtime.tools.arm-none-eabi-gcc-7-2017q4.path}/bin/
+compiler.path={runtime.tools.arm-none-eabi-gcc.path}/bin/
 compiler.c.cmd=arm-none-eabi-gcc
 compiler.c.flags=-mcpu={build.mcu} -mthumb -c -g -Os {compiler.warning_flags} -std=gnu11 -ffunction-sections -fdata-sections -nostdlib --param max-inline-insns-single=500 -MMD -D__SKETCH_NAME__="""{build.project_name}"""
 compiler.c.elf.cmd=arm-none-eabi-g++

--- a/platform.txt
+++ b/platform.txt
@@ -70,8 +70,8 @@ compiler.S.extra_flags=
 compiler.ar.extra_flags=
 compiler.elf2hex.extra_flags=
 
-compiler.arm.cmsis.c.flags="-I{runtime.tools.CMSIS-4.5.0.path}/CMSIS/Include/" "-I{runtime.tools.CMSIS-Atmel-1.2.0.path}/CMSIS/Device/ATMEL/"
-compiler.arm.cmsis.ldflags="-L{runtime.tools.CMSIS-4.5.0.path}/CMSIS/Lib/GCC/" -larm_cortexM0l_math
+compiler.arm.cmsis.c.flags="-I{runtime.tools.CMSIS-5.4.0.path}/CMSIS/Core/Include/" "-I{runtime.tools.CMSIS-5.4.0.path}/CMSIS/DSP/Include/" "-I{runtime.tools.CMSIS-Atmel-1.2.0.path}/CMSIS/Device/ATMEL/"
+compiler.arm.cmsis.ldflags="-L{runtime.tools.CMSIS-5.4.0.path}/CMSIS/Lib/GCC/" -larm_cortexM0l_math
 
 compiler.libraries.ldflags=
 

--- a/platform.txt
+++ b/platform.txt
@@ -20,7 +20,7 @@
 # https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5---3rd-party-Hardware-specification
 
 name=Adafruit SAMD (32-bits ARM Cortex-M0+ and Cortex-M4) Boards
-version=1.5.15
+version=1.6.0
 
 # Compile variables
 # -----------------


### PR DESCRIPTION
- Removed the 7-2017q4  specific compiler from platform.txt to allow updating to gcc 9-2019q4 like nrf52
- Update CMSIS from 4.5.0 to 5.4.0 . Like current SAMD packaging, CMSIS is a separated **tools* for header include and dsp lib only. The tarball download file is linked directly to ARM release tag https://github.com/ARM-software/CMSIS_5/releases/tag/5.4.0 
- Revert update TinyUSB Core

Note: Due to this issue https://github.com/isaacs/github/issues/1392 the 5.5.0 and up to latest (5.7.0) release tar file doesn't included the actual DSP lib file  `libarm_cortexM4lf_math.a` but only its ref link to github large file storage location. Therefore we should skip those latest for now, and update later on. There shouldn't be much of differences.

