### PR TITLE
Fixed/Added SPI DMA features in SPI library.

### DIFF
--- a/libraries/Adafruit_ZeroDMA/Adafruit_ZeroDMA.cpp
+++ b/libraries/Adafruit_ZeroDMA/Adafruit_ZeroDMA.cpp
@@ -449,7 +449,7 @@ bool Adafruit_ZeroDMA::isActive(void) const {
 DmacDescriptor *Adafruit_ZeroDMA::addDescriptor(
   void           *src,
   void           *dst,
-  uint32_t        count,
+  uint16_t        count,
   dma_beat_size   size,
   bool            srcInc,
   bool            dstInc,
@@ -537,7 +537,7 @@ DmacDescriptor *Adafruit_ZeroDMA::addDescriptor(
 // etc.) are unchanged.  Mostly for changing the data being pushed to a
 // peripheral (DAC, SPI, whatev.)
 void Adafruit_ZeroDMA::changeDescriptor(DmacDescriptor *desc,
-  void *src, void *dst, uint32_t count) {
+  void *src, void *dst, uint16_t count) {
 
     uint8_t bytesPerBeat; // Beat transfer size IN BYTES
     switch(desc->BTCTRL.bit.BEATSIZE) {

--- a/libraries/Adafruit_ZeroDMA/Adafruit_ZeroDMA.h
+++ b/libraries/Adafruit_ZeroDMA/Adafruit_ZeroDMA.h
@@ -41,13 +41,13 @@ class Adafruit_ZeroDMA {
   uint8_t         getChannel(void) const { return channel; }
 
   // DMA descriptor functions
-  DmacDescriptor *addDescriptor(void *src, void *dst, uint32_t count = 0,
+  DmacDescriptor *addDescriptor(void *src, void *dst, uint16_t count = 0,
                     dma_beat_size size = DMA_BEAT_SIZE_BYTE,
                     bool srcInc = true, bool dstInc = true, 
                     uint32_t stepSize = DMA_ADDRESS_INCREMENT_STEP_SIZE_1, 
                     bool stepSel = DMA_STEPSEL_DST);
   void            changeDescriptor(DmacDescriptor *d, void *src = NULL,
-                    void *dst = NULL, uint32_t count = 0);
+                    void *dst = NULL, uint16_t count = 0);
   bool            isActive(void) const;
 
   void            _IRQhandler(uint8_t flags); // DO NOT TOUCH

--- a/libraries/SPI/SPI.cpp
+++ b/libraries/SPI/SPI.cpp
@@ -235,155 +235,146 @@ void SPIClass::transfer(void *buf, size_t count)
   }
 }
 
+// Non-DMA transfer function.
+// this was removed from the dma function and made its own
+void SPIClass::transfer(void* txbuf, void* rxbuf, size_t count)
+{
+    uint8_t *txbuf8 = (uint8_t *)txbuf,
+            *rxbuf8 = (uint8_t *)rxbuf;
+    if(rxbuf8) {
+        if(txbuf8) {
+            // Writing and reading simultaneously
+            while(count--) {
+                *rxbuf8++ = _p_sercom->transferDataSPI(*txbuf8++);
+            }
+        } else {
+            // Reading only
+            while(count--) {
+                *rxbuf8++ = _p_sercom->transferDataSPI(0xFF);
+            }
+        }
+    } else if(txbuf) {
+        // Writing only
+        while(count--) {
+            (void)_p_sercom->transferDataSPI(*txbuf8++);
+        }
+    }
+}
+
+
 // Pointer to SPIClass object, one per DMA channel.
 static SPIClass *spiPtr[DMAC_CH_NUM] = { 0 }; // Legit inits list to NULL
 
-void SPIClass::dmaCallback(Adafruit_ZeroDMA *dma) {
-  // dmaCallback() receives an Adafruit_ZeroDMA object. From this we can get
-  // a channel number (0 to DMAC_CH_NUM-1, always unique per ZeroDMA object),
-  // then locate the originating SPIClass object using array lookup, setting
-  // the dma_busy element 'false' to indicate end of transfer.
-  spiPtr[dma->getChannel()]->dma_busy = false;
+// dma callback when the read part is completed
+void SPIClass::dmaCallback_read(Adafruit_ZeroDMA *dma)
+{
+	// dmaCallback() receives an Adafruit_ZeroDMA object. From this we can get
+	// a channel number (0 to DMAC_CH_NUM-1, always unique per ZeroDMA object),
+	// then locate the originating SPIClass object using array lookup, setting
+	uint8_t channel = dma->getChannel();
+
+	// flag this part of the dma done
+	spiPtr[channel]->dma_read_done = true;
+
+	// read and write dmas are both done
+	if(spiPtr[channel]->dma_read_done && spiPtr[channel]->dma_write_done)
+	{
+		// call the callback function the user specified
+		spiPtr[channel]->userDmaCallback();
+	}
 }
 
-void SPIClass::transfer(const void* txbuf, void* rxbuf, size_t count,
-  bool block) {
+// dma callback when the write part is completed
+void SPIClass::dmaCallback_write(Adafruit_ZeroDMA *dma)
+{
+	// dmaCallback() receives an Adafruit_ZeroDMA object. From this we can get
+	// a channel number (0 to DMAC_CH_NUM-1, always unique per ZeroDMA object),
+	// then locate the originating SPIClass object using array lookup, setting
+	uint8_t channel = dma->getChannel();
 
-    // If receiving data and the RX DMA channel is not yet allocated...
-    if(rxbuf && (readChannel.getChannel() >= DMAC_CH_NUM)) {
-        if(readChannel.allocate() == DMA_STATUS_OK) {
-            readDescriptor =
-              readChannel.addDescriptor(
+	// flag this part of the dma done
+	spiPtr[channel]->dma_write_done = true;
+
+	// read and write dmas are both done
+	if(spiPtr[channel]->dma_read_done && spiPtr[channel]->dma_write_done)
+	{
+		// call the callback function the user specified
+		spiPtr[channel]->userDmaCallback();
+	}
+}
+
+// dma transfer function for spi
+// this function does not block, and dma will transfer in the background
+// the callback parameter should be passed in by the user, it is called when the dma is done
+void SPIClass::transfer(void* txbuf, void* rxbuf, size_t count, void (*functionToCallWhenComplete)(void) )
+{
+	// save this function to call when the dma is done
+	userDmaCallback = functionToCallWhenComplete;
+
+	//******************************
+    // If the RX DMA channel is not yet allocated...
+    if(readChannel.getChannel() >= DMAC_CH_NUM)
+    {
+        if(readChannel.allocate() == DMA_STATUS_OK)
+        {
+            readDescriptor = readChannel.addDescriptor(
                 (void *)getDataRegister(), // Source address (SPI data reg)
-                NULL,                      // Dest address (set later)
-                0,                         // Count (set later)
+				rxbuf,                     // Dest address
+				count,                     // Count
                 DMA_BEAT_SIZE_BYTE,        // Bytes/hwords/words
                 false,                     // Don't increment source address
                 true);                     // Increment dest address
             readChannel.setTrigger(getDMAC_ID_RX());
             readChannel.setAction(DMA_TRIGGER_ACTON_BEAT);
+            readChannel.setCallback(dmaCallback_read, DMA_CALLBACK_TRANSFER_DONE);
             spiPtr[readChannel.getChannel()] = this;
-            // Since all RX transfers involve a TX, a
-            // separate callback here is not necessary.
         }
     }
+    else
+    {
+    	// update to use the currently passed buffers
+    	readChannel.changeDescriptor(
+    			readDescriptor,
+				(void *)getDataRegister(),	// Source address (SPI data reg)
+				rxbuf, 						// Dest address
+				count);						// Count
+    }
 
-    // Unlike the rxbuf check above, where a RX DMA channel is allocated
-    // only if receiving data (and channel not previously alloc'd), the
-    // TX DMA channel is always needed, because even RX-only SPI requires
-    // writing dummy bytes to the peripheral.
-    if(writeChannel.getChannel() >= DMAC_CH_NUM) {
-        if(writeChannel.allocate() == DMA_STATUS_OK) {
-            writeDescriptor =
-              writeChannel.addDescriptor(
-                NULL,                      // Source address (set later)
+    // If the TX DMA channel is not yet allocated...
+    if(writeChannel.getChannel() >= DMAC_CH_NUM)
+    {
+        if(writeChannel.allocate() == DMA_STATUS_OK)
+        {
+            writeDescriptor = writeChannel.addDescriptor(
+                txbuf,                     // Source address
                 (void *)getDataRegister(), // Dest (SPI data register)
-                0,                         // Count (set later)
+				count,                     // Count
                 DMA_BEAT_SIZE_BYTE,        // Bytes/hwords/words
                 true,                      // Increment source address
                 false);                    // Don't increment dest address
             writeChannel.setTrigger(getDMAC_ID_TX());
             writeChannel.setAction(DMA_TRIGGER_ACTON_BEAT);
-            writeChannel.setCallback(dmaCallback);
+            writeChannel.setCallback(dmaCallback_write, DMA_CALLBACK_TRANSFER_DONE);
             spiPtr[writeChannel.getChannel()] = this;
         }
     }
-
-    if(writeDescriptor && (readDescriptor || !rxbuf)) {
-        static const uint8_t dum = 0xFF; // Dummy byte for read-only xfers
-
-        // Initialize read descriptor dest address to rxbuf
-        if(rxbuf) readDescriptor->DSTADDR.reg = (uint32_t)rxbuf;
-
-        // If reading only, set up writeDescriptor to issue dummy bytes
-        // (set SRCADDR to &dum and SRCINC to 0). Otherwise, set SRCADDR
-        // to txbuf and SRCINC to 1. Only needed once at start.
-        if(rxbuf && !txbuf) {
-            writeDescriptor->SRCADDR.reg       = (uint32_t)&dum;
-            writeDescriptor->BTCTRL.bit.SRCINC = 0;
-        } else {
-            writeDescriptor->SRCADDR.reg       = (uint32_t)txbuf;
-            writeDescriptor->BTCTRL.bit.SRCINC = 1;
-        }
-
-        while(count > 0) {
-            // Maximum bytes per DMA descriptor is 65,535 (NOT 65,536).
-            // We could set up a descriptor chain, but that gets more
-            // complex. For now, instead, break up long transfers into
-            // chunks of 65,535 bytes max...these transfers are all
-            // blocking, regardless of the "block" argument, except
-            // for the last one which will observe the background request.
-            // The fractional part is done first, so for any "partially
-            // blocking" transfers like these at least it's the largest
-            // single-descriptor transfer possible that occurs in the
-            // background, rather than the tail end.
-            int  bytesThisPass;
-            bool blockThisPass;
-            if(count > 65535) { // Too big for 1 descriptor
-                blockThisPass = true;
-                bytesThisPass = count % 65535; // Fractional part
-                if(!bytesThisPass) bytesThisPass = 65535;
-            } else {
-                blockThisPass = block;
-                bytesThisPass = count;
-            }
-
-            // Issue 'bytesThisPass' bytes...
-            if(rxbuf) {
-                // Reading, or reading + writing.
-                // Set up read descriptor.
-                // Src address doesn't change, only dest & count.
-                // DMA needs address set to END of buffer, so
-                // increment the address now, before the transfer.
-                readDescriptor->DSTADDR.reg += bytesThisPass;
-                readDescriptor->BTCNT.reg    = bytesThisPass;
-                // Start the RX job BEFORE the TX job!
-                // That's the whole secret sauce to the two-channel transfer.
-                // Nothing will actually happen until the write channel job
-                // is also started.
-                readChannel.startJob();
-            }
-            if(txbuf) {
-                // DMA needs address set to END of buffer, so
-                // increment the address now, before the transfer.
-                writeDescriptor->SRCADDR.reg += bytesThisPass;
-            }
-            writeDescriptor->BTCNT.reg = bytesThisPass;
-            dma_busy = true;
-            writeChannel.startJob();
-            count   -= bytesThisPass;
-            if(blockThisPass) {
-                while(dma_busy);
-            }
-        }
-    } else {
-        // Non-DMA fallback.
-        uint8_t *txbuf8 = (uint8_t *)txbuf,
-                *rxbuf8 = (uint8_t *)rxbuf;
-        if(rxbuf8) {
-            if(txbuf8) {
-                // Writing and reading simultaneously
-                while(count--) {
-                    *rxbuf8++ = _p_sercom->transferDataSPI(*txbuf8++);
-                }
-            } else {
-                // Reading only
-                while(count--) {
-                    *rxbuf8++ = _p_sercom->transferDataSPI(0xFF);
-                }
-            }
-        } else if(txbuf) {
-            // Writing only
-            while(count--) {
-                (void)_p_sercom->transferDataSPI(*txbuf8++);
-            }
-        }
+    else
+    {
+    	// update to use the currently passed buffers
+    	writeChannel.changeDescriptor(
+    			writeDescriptor,
+				txbuf,						// Source address
+				(void *)getDataRegister(),	// Dest (SPI data register)
+				count);						// Count
     }
-}
 
-// Waits for a prior in-background DMA transfer to complete.
-void SPIClass::waitForTransfer(void) {
-    while(dma_busy);
+    //******************************
+    // clear the flags
+    // fire the dma transactions
+	dma_read_done  = false;
+	dma_write_done = false;
+	readChannel.startJob();
+	writeChannel.startJob();
 }
 
 void SPIClass::attachInterrupt() {

--- a/libraries/SPI/SPI.cpp
+++ b/libraries/SPI/SPI.cpp
@@ -330,10 +330,10 @@ void SPIClass::checkDmaComplete(uint8_t channel)
 	}
 }
 
-// dma transfer function for spi with pole for completion
+// dma transfer function for spi with poll for completion
 void SPIClass::transfer(const void* txbuf, void* rxbuf, uint32_t count, bool block)
 {
-	// start the dma transfer, but do not specify a user callback function, will pole for completion instead
+	// start the dma transfer, but do not specify a user callback function, will poll for completion instead
 	transfer(txbuf, rxbuf, count, NULL);
 
 	// if this function should automatically wait for completion, otherwise user must do manually

--- a/libraries/SPI/SPI.h
+++ b/libraries/SPI/SPI.h
@@ -118,8 +118,8 @@ class SPIClass {
   uint16_t transfer16(uint16_t data);
   void transfer(void *buf, size_t count);
   void transfer(void* txbuf, void* rxbuf, size_t count); //non dma
-  void transfer(const void* txbuf, void* rxbuf, uint32_t count, bool block = true); //dma pole for completion
-  void waitForTransfer(void); //dma pole for completion
+  void transfer(const void* txbuf, void* rxbuf, uint32_t count, bool block = true); //dma poll for completion
+  void waitForTransfer(void); //dma poll for completion
   void transfer(void* txbuf, void* rxbuf, uint32_t count, void (*functionToCallWhenComplete)(void) ); //dma asynchronous
 
   // Transaction Functions

--- a/libraries/SPI/SPI.h
+++ b/libraries/SPI/SPI.h
@@ -117,8 +117,8 @@ class SPIClass {
   byte transfer(uint8_t data);
   uint16_t transfer16(uint16_t data);
   void transfer(void *buf, size_t count);
-  void transfer(void* txbuf, void* rxbuf, size_t count); //non dma
-  void transfer(const void* txbuf, void* rxbuf, uint32_t count, bool block = true); //dma poll for completion
+  //void transfer(void* txbuf, void* rxbuf, size_t count); //non dma
+  void transfer(void* txbuf, void* rxbuf, uint32_t count, bool block); //dma poll for completion
   void waitForTransfer(void); //dma poll for completion
   void transfer(void* txbuf, void* rxbuf, uint32_t count, void (*functionToCallWhenComplete)(void) ); //dma asynchronous
 
@@ -180,12 +180,12 @@ class SPIClass {
   DmacDescriptor  *readDescriptor  = NULL;
   DmacDescriptor  *writeDescriptor = NULL;
 
-  volatile bool    dma_write_done 	 = false;		// true when read dma callback completes
-  volatile bool    dma_read_done  	 = false;		// true when write dma callback completes
-  uint32_t 		   dma_bytes_remaining;				// number of bytes remaining for future dma transactions
-  volatile bool    dma_complete  	 = false;		// all transactions completed and no bytes remaining
-  void* 		   txbuf_last;						// pointer to buffer last used
-  void* 		   rxbuf_last;						// pointer to buffer last used
+  volatile bool    dma_write_done 	 	= false;		// true when read dma callback completes
+  volatile bool    dma_read_done  	 	= false;		// true when write dma callback completes
+  uint32_t 		   dma_bytes_remaining 	= 0;			// number of bytes remaining for future dma transactions
+  volatile bool    dma_complete  	 	= false;		// all transactions completed and no bytes remaining
+  void* 		   txbuf_last			= NULL;			// pointer to buffer last used
+  void* 		   rxbuf_last			= NULL;			// pointer to buffer last used
 
   static void      dmaCallback_read(Adafruit_ZeroDMA *dma);
   static void      dmaCallback_write(Adafruit_ZeroDMA *dma);

--- a/libraries/SPI/SPI.h
+++ b/libraries/SPI/SPI.h
@@ -117,9 +117,8 @@ class SPIClass {
   byte transfer(uint8_t data);
   uint16_t transfer16(uint16_t data);
   void transfer(void *buf, size_t count);
-  void transfer(const void* txbuf, void* rxbuf, size_t count,
-         bool block = true);
-  void waitForTransfer(void);
+  void transfer(void* txbuf, void* rxbuf, size_t count); //non dma
+  void transfer(void* txbuf, void* rxbuf, size_t count, void (*functionToCallWhenComplete)(void) ); //dma
 
   // Transaction Functions
   void usingInterrupt(int interruptNumber);
@@ -169,13 +168,16 @@ class SPIClass {
   char interruptSave;
   uint32_t interruptMask;
 
-  // transfer(txbuf, rxbuf, count, block) uses DMA if possible
-  Adafruit_ZeroDMA readChannel,
-                   writeChannel;
-  DmacDescriptor  *readDescriptor  = NULL,
-                  *writeDescriptor = NULL;
-  volatile bool    dma_busy = false;
-  static void      dmaCallback(Adafruit_ZeroDMA *dma);
+  // objects and functions used for dma transfer
+  Adafruit_ZeroDMA readChannel;
+  Adafruit_ZeroDMA writeChannel;
+  DmacDescriptor  *readDescriptor  = NULL;
+  DmacDescriptor  *writeDescriptor = NULL;
+  volatile bool    dma_write_done 	 = false;
+  volatile bool    dma_read_done  	 = false;
+  static void      dmaCallback_read(Adafruit_ZeroDMA *dma);
+  static void      dmaCallback_write(Adafruit_ZeroDMA *dma);
+  void (*userDmaCallback)(void) = NULL; //function pointer to users dma callback function						 
 };
 
 #if SPI_INTERFACES_COUNT > 0

--- a/libraries/SPI/SPI.h
+++ b/libraries/SPI/SPI.h
@@ -118,7 +118,9 @@ class SPIClass {
   uint16_t transfer16(uint16_t data);
   void transfer(void *buf, size_t count);
   void transfer(void* txbuf, void* rxbuf, size_t count); //non dma
-  void transfer(void* txbuf, void* rxbuf, size_t count, void (*functionToCallWhenComplete)(void) ); //dma
+  void transfer(const void* txbuf, void* rxbuf, uint32_t count, bool block = true); //dma pole for completion
+  void waitForTransfer(void); //dma pole for completion
+  void transfer(void* txbuf, void* rxbuf, uint32_t count, void (*functionToCallWhenComplete)(void) ); //dma asynchronous
 
   // Transaction Functions
   void usingInterrupt(int interruptNumber);
@@ -175,9 +177,11 @@ class SPIClass {
   DmacDescriptor  *writeDescriptor = NULL;
   volatile bool    dma_write_done 	 = false;
   volatile bool    dma_read_done  	 = false;
+  size_t 		   dma_bytes_remaining;
   static void      dmaCallback_read(Adafruit_ZeroDMA *dma);
   static void      dmaCallback_write(Adafruit_ZeroDMA *dma);
-  void (*userDmaCallback)(void) = NULL; //function pointer to users dma callback function						 
+  void (*userDmaCallback)(void) = NULL; //function pointer to users dma callback function
+
 };
 
 #if SPI_INTERFACES_COUNT > 0

--- a/libraries/SPI/SPI.h
+++ b/libraries/SPI/SPI.h
@@ -170,16 +170,26 @@ class SPIClass {
   char interruptSave;
   uint32_t interruptMask;
 
-  // objects and functions used for dma transfer
+  //***********************************************************
+  // constants, objects, and functions used for dma transfers
+
+  #define DMA_MAX_TRANSFER_SIZE		65535			// maximum bytes a dma can transfer per transaction
+
   Adafruit_ZeroDMA readChannel;
   Adafruit_ZeroDMA writeChannel;
   DmacDescriptor  *readDescriptor  = NULL;
   DmacDescriptor  *writeDescriptor = NULL;
-  volatile bool    dma_write_done 	 = false;
-  volatile bool    dma_read_done  	 = false;
-  size_t 		   dma_bytes_remaining;
+
+  volatile bool    dma_write_done 	 = false;		// true when read dma callback completes
+  volatile bool    dma_read_done  	 = false;		// true when write dma callback completes
+  uint32_t 		   dma_bytes_remaining;				// number of bytes remaining for future dma transactions
+  volatile bool    dma_complete  	 = false;		// all transactions completed and no bytes remaining
+  void* 		   txbuf_last;						// pointer to buffer last used
+  void* 		   rxbuf_last;						// pointer to buffer last used
+
   static void      dmaCallback_read(Adafruit_ZeroDMA *dma);
   static void      dmaCallback_write(Adafruit_ZeroDMA *dma);
+  static void      checkDmaComplete(uint8_t channel);
   void (*userDmaCallback)(void) = NULL; //function pointer to users dma callback function
 
 };

--- a/libraries/SPI/examples/zerodma_spi1/zerodma_spi1.ino
+++ b/libraries/SPI/examples/zerodma_spi1/zerodma_spi1.ino
@@ -1,0 +1,144 @@
+// DMA-based SPI buffer write.
+// Will setup a dma transaction to read and write data over the spi
+// Callback will be called when the dma is completed
+
+#include <SPI.h>
+#include <Math.h>
+//#define PRINT_MEMMORY_BUFFERS
+
+#define SS	2
+
+// The memory we'll be issuing to SPI:
+#define DATA_LENGTH 4096
+uint8_t send_memory[DATA_LENGTH];
+uint8_t receive_memory[DATA_LENGTH];
+
+//******************************************************************************************
+
+// Show contents of array
+void dump(uint8_t *memory)
+{
+  const int BASE 		= 16; //hex formatting
+  const int PAD_AMMOUNT = 4;  //digits
+
+  for(uint32_t i=0; i<DATA_LENGTH; i++)
+  {
+    // pas numbers this many digits
+    for(int c=1; c<PAD_AMMOUNT; ++c)
+    {
+    	if( memory[i] < pow(BASE, c) )
+    	{
+    		// pad with spaces
+    		Serial.print(" ");
+    	}
+    }
+
+    // print the number
+    Serial.print(memory[i], BASE);
+
+    // new line when about to wrap around in base
+    if ((i % BASE) == BASE-1)
+    {
+    	Serial.println();
+    }
+  }
+  Serial.println();
+}
+
+//******************************************************************************************
+
+// Callback for end-of-DMA-transfer
+volatile bool dmaDone = false;
+void callback_dmaDone()
+{
+	//Serial.println("Callback: Dma Done");
+	dmaDone = true;
+}
+
+//******************************************************************************************
+
+void setup()
+{
+	pinMode(SS, OUTPUT);
+	digitalWrite(SS, HIGH); //high is spi deaserted
+
+	Serial.begin(115200);
+	//while(!Serial);                 // Wait for Serial monitor before continuing
+	Serial.println("***********************");
+	Serial.println("Program Start");
+	Serial.println("***********************");
+	delay(1000);
+
+	// initialize spi
+	SPI.begin();
+	//*************
+
+	Serial.println("Initing buffers");
+	// init the data buffers
+	for(uint32_t i=0; i<DATA_LENGTH; i++)
+	{
+	  send_memory[i] 	= 0x33;
+	  receive_memory[i] = 0x55;
+	}
+	#ifdef PRINT_MEMMORY_BUFFERS
+		Serial.println("send_memory: ");
+		dump(send_memory);
+		Serial.println("destination_memory: ");
+		dump(receive_memory);
+		delay(1000);
+	#endif
+
+}
+
+//******************************************************************************************
+
+void loop()
+{
+	Serial.println("***********************");
+	Serial.println("Starting transfer ...");
+
+	// enable Slave Select
+	SPI.beginTransaction(SPISettings(25000000, MSBFIRST, SPI_MODE1));
+	digitalWrite(SS, LOW);
+
+	// send the command byte
+	//SPI.transfer(255);
+
+	#if(1)
+		// dma transfer
+		// reset the transaction flag
+		dmaDone = false;
+
+		// calls the dma transfer, this call does not block
+		// will call the callback frunction when the dma is completed
+		SPI.transfer(send_memory, receive_memory, DATA_LENGTH, callback_dmaDone); //dma
+
+		// can do other things here...
+		// can do rtos things like block/yield rtos task and schedule others
+		// can do rtos things like block on a dma semaphores here
+		
+		// wait here until transfer is completed
+		while(!dmaDone); // this is updated by our callback function
+
+	#else
+		//non dma transfer
+		SPI.transfer(send_memory, receive_memory, DATA_LENGTH);
+	#endif
+
+	// disable Slave Select
+	digitalWrite(SS, HIGH);
+	SPI.endTransaction();
+	Serial.println("Done! ");
+
+	//*************
+
+	#ifdef PRINT_MEMMORY_BUFFERS
+		Serial.println("send_memory: ");
+		dump(send_memory);
+		Serial.println("receive_memory: ");
+		dump(receive_memory);
+		delay(1000);
+	#endif
+
+	delay(100);
+}

--- a/libraries/SPI/examples/zerodma_spi1/zerodma_spi1.ino
+++ b/libraries/SPI/examples/zerodma_spi1/zerodma_spi1.ino
@@ -122,12 +122,12 @@ void loop()
 		while(!dmaDone); // this is updated by our callback function
 
 	#elif(DMA_TEST == 2)
-		// dma transfer pole for completion
+		// dma transfer poll for completion
 		// calls the dma transfer, this call will block
 		SPI.transfer(send_memory, receive_memory, DATA_LENGTH, true); //dma
 
 	#elif(DMA_TEST == 3)
-		// dma transfer pole for completion
+		// dma transfer poll for completion
 		// calls the dma transfer, this call will not block
 		SPI.transfer(send_memory, receive_memory, DATA_LENGTH, false); //dma
 

--- a/libraries/SPI/examples/zerodma_spi1/zerodma_spi1.ino
+++ b/libraries/SPI/examples/zerodma_spi1/zerodma_spi1.ino
@@ -104,14 +104,14 @@ void loop()
 	// send the command byte
 	//SPI.transfer(255);
 
-	#define DMA_TEST 3 //select the type of dma to test
+	#define DMA_TEST 1 //select the type of dma to test
 	#if(DMA_TEST == 1)
 		// asyncronous dma transfer
 		// reset the transaction flag
 		dmaDone = false;
 
 		// calls the dma transfer, this call does not block
-		// will call the callback frunction when the dma is completed
+		// will call the callback function when the dma is completed
 		SPI.transfer(send_memory, receive_memory, DATA_LENGTH, callback_dmaDone); //dma
 
 		// can do other things here...

--- a/libraries/SPI/examples/zerodma_spi1/zerodma_spi1.ino
+++ b/libraries/SPI/examples/zerodma_spi1/zerodma_spi1.ino
@@ -104,8 +104,9 @@ void loop()
 	// send the command byte
 	//SPI.transfer(255);
 
-	#if(1)
-		// dma transfer
+	#define DMA_TEST 3 //select the type of dma to test
+	#if(DMA_TEST == 1)
+		// asyncronous dma transfer
 		// reset the transaction flag
 		dmaDone = false;
 
@@ -120,9 +121,25 @@ void loop()
 		// wait here until transfer is completed
 		while(!dmaDone); // this is updated by our callback function
 
-	#else
+	#elif(DMA_TEST == 2)
+		// dma transfer pole for completion
+		// calls the dma transfer, this call will block
+		SPI.transfer(send_memory, receive_memory, DATA_LENGTH, true); //dma
+
+	#elif(DMA_TEST == 3)
+		// dma transfer pole for completion
+		// calls the dma transfer, this call will not block
+		SPI.transfer(send_memory, receive_memory, DATA_LENGTH, false); //dma
+
+		// can do other things here...
+
+		// wait here until transfer is completed
+		SPI.waitForTransfer();
+
+	#elif(DMA_TEST == 4)
 		//non dma transfer
 		SPI.transfer(send_memory, receive_memory, DATA_LENGTH);
+
 	#endif
 
 	// disable Slave Select


### PR DESCRIPTION
Hello Everyone,

This are my fixes and additions to the SPI library. This address issue #230 and #225, as well as an additional undocumented bug.

Let me know what you think :-)


* Bug Fix. SPI DMA required to wait for both read and write dmas to complete before we can say the entire spi transfer is completed.
* Bug Fix. A read only spi dma is not possible because both dmas are required for spi signal timing to work properly. Verified on oscilloscope. Just call the function and pass it empty buffers if you dont care about the rx or tx results, and ignore them.
* Bug Fix. SPI DMA buffers were initialized once, and subsequent calls would not allow for new buffer pointers.
* Bug/Feature Added. Previous dma was not truly asynchronous. Was poling for dma completion. Callback added to allow for true asynchronous transfers. Dma is now rtos friendly.
* Added example program to show how to do a spi dma and setup a callback function when completed.