### PR TITLE
Handle analogRead(n) for n in 8..15

### DIFF
--- a/cores/arduino/wiring_analog.c
+++ b/cores/arduino/wiring_analog.c
@@ -274,7 +274,7 @@ uint32_t analogRead(uint32_t pin)
   if (pin <= 5) {
     pin += A0;
   }
-#if NUM_ANALOG_PINS > 8
+#if NUM_ANALOG_INPUTS > 8
   else if (pin < 16) {     // Grand Central's extra 8 pins are discontinuous
     pin += PIN_A8 - 8;     //   and are on LOWER digital Pins than A0..A7
   }

--- a/cores/arduino/wiring_analog.c
+++ b/cores/arduino/wiring_analog.c
@@ -274,6 +274,11 @@ uint32_t analogRead(uint32_t pin)
   if (pin <= 5) {
     pin += A0;
   }
+#if NUM_ANALOG_PINS > 8
+  else if (pin < 16) {     // Grand Central's extra 8 pins are discontinuous
+    pin += PIN_A8 - 8;     //   and are on LOWER digital Pins than A0..A7
+  }
+#endif
 
   pinPeripheral(pin, PIO_ANALOG);
  //ATSAMR, for example, doesn't have a DAC


### PR DESCRIPTION
Let's try this again...

The code in analogRead() does not not handle integer arguments of 8..15, which are valid analog pins on Grand Central. Worse, it will do "bad things", like setting PINMUX to "analog" on pins that don't even have analog support.
#236