### PR TITLE
Enable Interrupt #8 on Pin PORTA28 (GPIO2)

### DIFF
--- a/variants/pirkey/variant.cpp
+++ b/variants/pirkey/variant.cpp
@@ -29,7 +29,7 @@ const PinDescription g_APinDescription[]=
   { PORTA,  1, PIO_DIGITAL, 0, ADC_Channel5, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_1 }, // ADC/AIN[5]
 
   // GPIO 2 - Infrared In
-  { PORTA, 28, PIO_COM, PIN_ATTR_NONE, No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_NONE }, // USB Host enable - GPIO #2
+  { PORTA, 28, PIO_COM, PIN_ATTR_NONE, No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_8 }, // USB Host enable - GPIO #2
 
   // GPIO 3 & 4 (SWCLK & SWDIO)
   // --------------------------


### PR DESCRIPTION
In order to use IRLibRecvPCI class from IRLib2 with Adafruit pIRKey, it's necessary to allow interrupts on this pin.