### PR TITLE
ZeroDMA: Allocate descriptors from local buffer

### DIFF
--- a/libraries/Adafruit_ZeroDMA/Adafruit_ZeroDMA.h
+++ b/libraries/Adafruit_ZeroDMA/Adafruit_ZeroDMA.h
@@ -4,6 +4,10 @@
 #include "Arduino.h"
 #include "utility/dma.h"
 
+#ifndef DMAC_DESC_HEAP_SIZE
+#define DMAC_DESC_HEAP_SIZE 4
+#endif
+
 // Status codes returned by some DMA functions and/or held in
 // a channel's jobStatus variable.
 enum ZeroDMAstatus {
@@ -54,6 +58,8 @@ class Adafruit_ZeroDMA {
 
 
  protected:  
+  __attribute__((__aligned__(16))) uint8_t desc_heap[DMAC_DESC_HEAP_SIZE*16];
+  DmacDescriptor *            alloc_descriptor();
   uint8_t                     channel;
   volatile enum ZeroDMAstatus jobStatus;
   bool                        hasDescriptors;
@@ -61,6 +67,7 @@ class Adafruit_ZeroDMA {
   uint8_t                     peripheralTrigger;
   dma_transfer_trigger_action triggerAction;
   void                      (*callback[DMA_CALLBACK_N])(Adafruit_ZeroDMA *);
+  size_t                      allocated = 0;
 };
 
 #endif // _ADAFRUIT_ZERODMA_H_


### PR DESCRIPTION
- `memalign()` is deprecated
- In the current configuration, `free()`ing the memory is left to the user, but very little warning is given
- manual `free()` is not a common pattern within the Arduino Ecosystem. Most things are either static, or RAII-allocated as part of C++ classes.
- `addDescriptor()` always returns a pointer, and doesn't tell the user if that pointer was heap-allocated or part of the static `_descriptor` structure. This would make a correct user implementation very difficult.
- In threaded/tasked systems, multiple tasks may try to `memalign()` concurrently. I don't have faith the built-in malloc() is thread-safe.
- `malloc()` time is non-deterministic
- Even on the largest SAMD51, the entire SRAM could be moved with only 4 descriptors. I think applications with involving that much data would be rare, and the `#define` override would allow easy adjustment.
- This change does not effect any APIs