### PR TITLE
update LED_BUILTIN for matrixportal_m4

### DIFF
--- a/variants/matrixportal_m4/variant.h
+++ b/variants/matrixportal_m4/variant.h
@@ -81,13 +81,13 @@ extern "C"
 // #define digitalPinToTimer(P)
 
 // LEDs
-#define PIN_LED_47           (47u)
+#define PIN_LED_13           (13u)
 //#define PIN_LED_RXL          (25u)
 //#define PIN_LED_TXL          (26u)
-#define PIN_LED              PIN_LED_47
+#define PIN_LED              PIN_LED_13
 //#define PIN_LED2             PIN_LED_RXL
 //#define PIN_LED3             PIN_LED_TXL
-#define LED_BUILTIN          PIN_LED_47
+#define LED_BUILTIN          PIN_LED_13
 #define PIN_NEOPIXEL         (4)
 
 /*


### PR DESCRIPTION
I was having some problems with my Matrix Portal M4 project and I added some debug code to set the LED, but it didn't work. I loaded the Arduino example LED blink sketch, but that didn't work either.

It looks like originally the Matrix Portal M4 was not going to have an LED and then later one was added, but the value of LED_BUILTIN was not updated. According to variant.cpp it should be 13 (PORTA 14), but LED_BUILTIN was left using the old value 47 (used to be PORTA 15, disconnected on the schematic) which is now labeled as LIS IRQ (PORTA 27). With these changes, my LED is blinking.