### PR TITLE
Added a isBusy() method to SPI calls to allow non-blocking polling of…

### DIFF
--- a/libraries/SPI/SPI.cpp
+++ b/libraries/SPI/SPI.cpp
@@ -458,6 +458,12 @@ void SPIClass::waitForTransfer(void) {
   while(dma_busy);
 }
 
+/* returns the current DMA transfer status to allow non-blocking polling */
+bool SPIClass::isBusy(void) {
+  return dma_busy;
+}
+
+
 // End DMA-based SPI transfer() code ---------------------------------------
 
 void SPIClass::attachInterrupt() {

--- a/libraries/SPI/SPI.h
+++ b/libraries/SPI/SPI.h
@@ -120,6 +120,7 @@ class SPIClass {
   void transfer(const void* txbuf, void* rxbuf, size_t count,
          bool block = true);
   void waitForTransfer(void);
+  bool isBusy(void);
 
   // Transaction Functions
   void usingInterrupt(int interruptNumber);


### PR DESCRIPTION
… the DMA transfer status.

Well, the few added lines should speak for itself but this provides an alternative to SPI.waitForTransfer() which is blocking.
