### PR TITLE
Port some AVR Serial_ (SerialUSB) API's over

### DIFF
--- a/cores/arduino/USB/CDC.cpp
+++ b/cores/arduino/USB/CDC.cpp
@@ -259,6 +259,50 @@ Serial_::operator bool()
 	return result;
 }
 
+int32_t Serial_::readBreak() {
+	uint8_t enableInterrupts = ((__get_PRIMASK() & 0x1) == 0);
+
+	// disable interrupts,
+	// to avoid clearing a breakValue that might occur 
+	// while processing the current break value
+	__disable_irq();
+
+	int32_t ret = breakValue;
+
+	breakValue = -1;
+
+	if (enableInterrupts) {
+		// re-enable the interrupts
+		__enable_irq();
+	}
+
+	return ret;
+}
+
+unsigned long Serial_::baud() {
+	return _usbLineInfo.dwDTERate;
+}
+
+uint8_t Serial_::stopbits() {
+	return _usbLineInfo.bCharFormat;
+}
+
+uint8_t Serial_::paritytype() {
+	return _usbLineInfo.bParityType;
+}
+
+uint8_t Serial_::numbits() {
+	return _usbLineInfo.bDataBits;
+}
+
+bool Serial_::dtr() {
+	return _usbLineInfo.lineState & 0x1;
+}
+
+bool Serial_::rts() {
+	return _usbLineInfo.lineState & 0x2;
+}
+
 Serial_ Serial(USBDevice);
 
 #endif


### PR DESCRIPTION
This is a cherrypick of a commit by Sandeep Mistry from the upstream arduino/ArduinoCore-samd repository (tag 1.6.5 and later), that adds the following functions to the Serial_ class:

int32_t Serial_::readBreak();
unsigned long Serial_::baud();
uint8_t Serial_::stopbits();
uint8_t Serial_::paritytype();
uint8_t Serial_::numbits();
bool Serial_::dtr();
bool Serial_::rts();

I have a separate PR at https://github.com/adafruit/Adafruit_TinyUSB_ArduinoCore/pull/21 to add Serial_::dtr() to the TinyUSB version.