### PR TITLE
Cast to integral type ignores qualifier `volatile`

### DIFF
--- a/cores/arduino/Reset.cpp
+++ b/cores/arduino/Reset.cpp
@@ -29,7 +29,7 @@ extern "C" {
 #if (ARDUINO_SAMD_VARIANT_COMPLIANCE >= 10610)
 
 extern const uint32_t __text_start__;
-#define APP_START ((volatile uint32_t)(&__text_start__) + 4)
+#define APP_START ((uint32_t)(&__text_start__) + 4)
 
 #else
 


### PR DESCRIPTION
Attempting to cast to a `volatile uint32_t` does nothing different from cast to a `uint32_t`,
with the exception of **_looking like_** it's accessing a register.

Just remove the word `volatile` to fix.