### PR TITLE
Narrowly silence new (GCC 8.1+) warning

### DIFF
--- a/libraries/SPI/SPI.cpp
+++ b/libraries/SPI/SPI.cpp
@@ -334,12 +334,18 @@ void SPIClass::dmaAllocate(void) {
           extraWriteDescriptors = &extraReadDescriptors[numReadDescriptors];
           // Initialize descriptors (copy from first ones)
           for(int i=0; i<numReadDescriptors; i++) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wclass-memaccess"
             memcpy(&extraReadDescriptors[i], firstReadDescriptor,
               sizeof(DmacDescriptor));
+#pragma GCC diagnostic pop
           }
           for(int i=0; i<numWriteDescriptors; i++) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wclass-memaccess"
             memcpy(&extraWriteDescriptors[i], firstWriteDescriptor,
               sizeof(DmacDescriptor));
+#pragma GCC diagnostic pop
           }
         } // end malloc
       } // end extra descriptor check


### PR DESCRIPTION
Fixes #287

The warnings look like:
```
      Line 338 Char 37
      warning: 'void* memcpy(void*, const void*, size_t)' 
               writing to an object of type 'struct DmacDescriptor'
               with no trivial copy-assignment [-Wclass-memaccess]
```