### PR TITLE
Fix warnings

### DIFF
--- a/libraries/SPI/SPI.cpp
+++ b/libraries/SPI/SPI.cpp
@@ -333,24 +333,16 @@ void SPIClass::dmaAllocate(void) {
           use_dma = true; // Everything allocated successfully
           extraWriteDescriptors = &extraReadDescriptors[numReadDescriptors];
 
-          // dmac.h didn't include extern "C" which cause
-          // DmacDescriptor and its members are defined as C++ struct therefore
-          // memcpy will throw warning on copying where simple assignment won't work
-          #pragma GCC diagnostic push
-          #pragma GCC diagnostic ignored "-Wclass-memaccess"
-
           // Initialize descriptors (copy from first ones)
+          // cast to void* to suppress warning: with no trivial copy-assignment [-Wclass-memaccess]
           for(int i=0; i<numReadDescriptors; i++) {
-            memcpy(&extraReadDescriptors[i], firstReadDescriptor,
+            memcpy((void*) &extraReadDescriptors[i], firstReadDescriptor,
               sizeof(DmacDescriptor));
           }
           for(int i=0; i<numWriteDescriptors; i++) {
-            memcpy(&extraWriteDescriptors[i], firstWriteDescriptor,
+            memcpy((void*) &extraWriteDescriptors[i], firstWriteDescriptor,
               sizeof(DmacDescriptor));
           }
-
-          #pragma GCC diagnostic pop
-
         } // end malloc
       } // end extra descriptor check
 

--- a/platform.txt
+++ b/platform.txt
@@ -20,7 +20,7 @@
 # https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5---3rd-party-Hardware-specification
 
 name=Adafruit SAMD (32-bits ARM Cortex-M0+ and Cortex-M4) Boards
-version=1.7.0
+version=1.7.1
 
 # Compile variables
 # -----------------

--- a/platform.txt
+++ b/platform.txt
@@ -70,7 +70,7 @@ compiler.S.extra_flags=
 compiler.ar.extra_flags=
 compiler.elf2hex.extra_flags=
 
-compiler.arm.cmsis.c.flags="-I{runtime.tools.CMSIS-5.4.0.path}/CMSIS/Core/Include/" "-I{runtime.tools.CMSIS-5.4.0.path}/CMSIS/DSP/Include/" "-I{runtime.tools.CMSIS-Atmel-1.2.1.path}/CMSIS/Device/ATMEL/"
+compiler.arm.cmsis.c.flags="-I{runtime.tools.CMSIS-5.4.0.path}/CMSIS/Core/Include/" "-I{runtime.tools.CMSIS-5.4.0.path}/CMSIS/DSP/Include/" "-I{runtime.tools.CMSIS-Atmel-1.2.2.path}/CMSIS/Device/ATMEL/"
 compiler.arm.cmsis.ldflags="-L{runtime.tools.CMSIS-5.4.0.path}/CMSIS/Lib/GCC/" -larm_cortexM0l_math
 
 compiler.libraries.ldflags=


### PR DESCRIPTION
- use CMSIS-Atmel 1.2.2 to fix LITTLE_ENDIAN warnings https://github.com/adafruit/ArduinoModule-CMSIS-Atmel/releases/tag/v1.2.2
- Fix "-Wclass-memaccess" related to #290 
- bump tinyusb lib to 1.0.1

Update: CI failed since the CMSIS-Atmel 1.2.2 isn't released via arduino package json index just yet, while the package json need this to be merged first. Once package index is merged, we could re-run check to pass CI 