### PR TITLE
add -DADAFRUIT_ARCH_SAMD to all board's build.extra_flags

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -43,7 +43,7 @@ adafruit_feather_m0.build.usb_product="Feather M0"
 adafruit_feather_m0.build.usb_manufacturer="Adafruit"
 adafruit_feather_m0.build.board=SAMD_ZERO
 adafruit_feather_m0.build.core=arduino
-adafruit_feather_m0.build.extra_flags=-DARDUINO_SAMD_ZERO -DARM_MATH_CM0PLUS -DADAFRUIT_FEATHER_M0 -D__SAMD21G18A__ {build.usb_flags}
+adafruit_feather_m0.build.extra_flags=-DARDUINO_SAMD_ZERO -DARM_MATH_CM0PLUS -DADAFRUIT_FEATHER_M0 -D__SAMD21G18A__ -DADAFRUIT_ARCH_SAMD {build.usb_flags}
 adafruit_feather_m0.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_feather_m0.build.openocdscript=openocd_scripts/feather_m0.cfg
 adafruit_feather_m0.build.variant=feather_m0
@@ -90,7 +90,7 @@ adafruit_feather_m0_express.build.usb_product="Feather M0 Express"
 adafruit_feather_m0_express.build.usb_manufacturer="Adafruit"
 adafruit_feather_m0_express.build.board=SAMD_FEATHER_M0_EXPRESS
 adafruit_feather_m0_express.build.core=arduino
-adafruit_feather_m0_express.build.extra_flags=-DARDUINO_SAMD_ZERO -DARDUINO_SAMD_FEATHER_M0 -DARM_MATH_CM0PLUS -DADAFRUIT_FEATHER_M0_EXPRESS -D__SAMD21G18A__ {build.usb_flags}
+adafruit_feather_m0_express.build.extra_flags=-DARDUINO_SAMD_ZERO -DARDUINO_SAMD_FEATHER_M0 -DARM_MATH_CM0PLUS -DADAFRUIT_FEATHER_M0_EXPRESS -D__SAMD21G18A__ -DADAFRUIT_ARCH_SAMD {build.usb_flags}
 adafruit_feather_m0_express.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_feather_m0_express.build.openocdscript=openocd_scripts/feather_m0_express.cfg
 adafruit_feather_m0_express.build.variant=feather_m0_express
@@ -134,7 +134,7 @@ adafruit_feather_m0_express.menu.debug.on.build.flags.debug=-g
 #adafruit_radio_m0.build.usb_manufacturer="Adafruit"
 #adafruit_radio_m0.build.board=SAMD_ZERO
 #adafruit_radio_m0.build.core=arduino
-#adafruit_radio_m0.build.extra_flags=-D__SAMR21G18A__ -DARM_MATH_CM0PLUS {build.usb_flags}
+#adafruit_radio_m0.build.extra_flags=-D__SAMR21G18A__ -DARM_MATH_CM0PLUS -DADAFRUIT_ARCH_SAMD {build.usb_flags}
 #adafruit_radio_m0.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 #adafruit_radio_m0.build.openocdscript=openocd_scripts/zero_radio.cfg
 #adafruit_radio_m0.build.variant=zero_radio
@@ -164,7 +164,7 @@ adafruit_metro_m0.build.usb_product="Metro M0 Express"
 adafruit_metro_m0.build.usb_manufacturer="Adafruit"
 adafruit_metro_m0.build.board=SAMD_ZERO
 adafruit_metro_m0.build.core=arduino
-adafruit_metro_m0.build.extra_flags=-D__SAMD21G18A__ -DARDUINO_SAMD_ZERO -DARM_MATH_CM0PLUS -DADAFRUIT_METRO_M0_EXPRESS {build.usb_flags}
+adafruit_metro_m0.build.extra_flags=-D__SAMD21G18A__ -DARDUINO_SAMD_ZERO -DARM_MATH_CM0PLUS -DADAFRUIT_METRO_M0_EXPRESS -DADAFRUIT_ARCH_SAMD {build.usb_flags}
 adafruit_metro_m0.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_metro_m0.build.openocdscript=openocd_scripts/metro_m0.cfg
 adafruit_metro_m0.build.variant=metro_m0
@@ -211,7 +211,7 @@ adafruit_circuitplayground_m0.build.usb_product="Circuit Playground Express"
 adafruit_circuitplayground_m0.build.usb_manufacturer="Adafruit"
 adafruit_circuitplayground_m0.build.board=SAMD_CIRCUITPLAYGROUND_EXPRESS
 adafruit_circuitplayground_m0.build.core=arduino
-adafruit_circuitplayground_m0.build.extra_flags=-DCRYSTALLESS -DARDUINO_SAMD_ZERO -D__SAMD21G18A__ -DARM_MATH_CM0PLUS -DADAFRUIT_CIRCUITPLAYGROUND_M0 {build.usb_flags}
+adafruit_circuitplayground_m0.build.extra_flags=-DCRYSTALLESS -DARDUINO_SAMD_ZERO -D__SAMD21G18A__ -DARM_MATH_CM0PLUS -DADAFRUIT_CIRCUITPLAYGROUND_M0 -DADAFRUIT_ARCH_SAMD {build.usb_flags}
 adafruit_circuitplayground_m0.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_circuitplayground_m0.build.openocdscript=openocd_scripts/circuit_play.cfg
 adafruit_circuitplayground_m0.build.variant=circuitplay
@@ -258,7 +258,7 @@ adafruit_gemma_m0.build.usb_product="Gemma M0"
 adafruit_gemma_m0.build.usb_manufacturer="Adafruit"
 adafruit_gemma_m0.build.board=GEMMA_M0
 adafruit_gemma_m0.build.core=arduino
-adafruit_gemma_m0.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_GEMMA_M0 -D__SAMD21E18A__ -DARM_MATH_CM0PLUS {build.usb_flags}
+adafruit_gemma_m0.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_GEMMA_M0 -D__SAMD21E18A__ -DARM_MATH_CM0PLUS -DADAFRUIT_ARCH_SAMD {build.usb_flags}
 adafruit_gemma_m0.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_gemma_m0.build.openocdscript=openocd_scripts/gemma_m0.cfg
 adafruit_gemma_m0.build.variant=gemma_m0
@@ -304,7 +304,7 @@ adafruit_trinket_m0.build.usb_product="Trinket M0"
 adafruit_trinket_m0.build.usb_manufacturer="Adafruit"
 adafruit_trinket_m0.build.board=TRINKET_M0
 adafruit_trinket_m0.build.core=arduino
-adafruit_trinket_m0.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_TRINKET_M0 -D__SAMD21E18A__ -DARM_MATH_CM0PLUS {build.usb_flags}
+adafruit_trinket_m0.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_TRINKET_M0 -D__SAMD21E18A__ -DARM_MATH_CM0PLUS -DADAFRUIT_ARCH_SAMD {build.usb_flags}
 adafruit_trinket_m0.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_trinket_m0.build.openocdscript=openocd_scripts/trinket_m0.cfg
 adafruit_trinket_m0.build.variant=trinket_m0
@@ -352,7 +352,7 @@ adafruit_qtpy_m0.build.usb_product="QT Py M0"
 adafruit_qtpy_m0.build.usb_manufacturer="Adafruit"
 adafruit_qtpy_m0.build.board=QTPY_M0
 adafruit_qtpy_m0.build.core=arduino
-adafruit_qtpy_m0.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_QTPY_M0 -D__SAMD21E18A__ -DARM_MATH_CM0PLUS {build.usb_flags}
+adafruit_qtpy_m0.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_QTPY_M0 -D__SAMD21E18A__ -DARM_MATH_CM0PLUS -DADAFRUIT_ARCH_SAMD {build.usb_flags}
 adafruit_qtpy_m0.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_qtpy_m0.build.openocdscript=openocd_scripts/trinket_m0.cfg
 adafruit_qtpy_m0.build.variant=qtpy_m0
@@ -400,7 +400,7 @@ adafruit_neotrinkey_m0.build.usb_product="NeoPixel Trinkey M0"
 adafruit_neotrinkey_m0.build.usb_manufacturer="Adafruit"
 adafruit_neotrinkey_m0.build.board=NEOTRINKEY_M0
 adafruit_neotrinkey_m0.build.core=arduino
-adafruit_neotrinkey_m0.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_NEOTRINKEY_M0 -D__SAMD21E18A__ -DARM_MATH_CM0PLUS {build.usb_flags}
+adafruit_neotrinkey_m0.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_NEOTRINKEY_M0 -D__SAMD21E18A__ -DARM_MATH_CM0PLUS -DADAFRUIT_ARCH_SAMD {build.usb_flags}
 adafruit_neotrinkey_m0.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_neotrinkey_m0.build.openocdscript=openocd_scripts/neotrinkey_m0.cfg
 adafruit_neotrinkey_m0.build.variant=neotrinkey_m0
@@ -448,7 +448,7 @@ adafruit_rotarytrinkey_m0.build.usb_product="Rotary Trinkey M0"
 adafruit_rotarytrinkey_m0.build.usb_manufacturer="Adafruit"
 adafruit_rotarytrinkey_m0.build.board=ROTARYTRINKEY_M0
 adafruit_rotarytrinkey_m0.build.core=arduino
-adafruit_rotarytrinkey_m0.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_ROTARYTRINKEY_M0 -D__SAMD21E18A__ -DARM_MATH_CM0PLUS {build.usb_flags}
+adafruit_rotarytrinkey_m0.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_ROTARYTRINKEY_M0 -D__SAMD21E18A__ -DARM_MATH_CM0PLUS -DADAFRUIT_ARCH_SAMD {build.usb_flags}
 adafruit_rotarytrinkey_m0.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_rotarytrinkey_m0.build.openocdscript=openocd_scripts/rotarytrinkey_m0.cfg
 adafruit_rotarytrinkey_m0.build.variant=rotarytrinkey_m0
@@ -496,7 +496,7 @@ adafruit_neokeytrinkey_m0.build.usb_product="NeoKey Trinkey M0"
 adafruit_neokeytrinkey_m0.build.usb_manufacturer="Adafruit"
 adafruit_neokeytrinkey_m0.build.board=NEOKEYTRINKEY_M0
 adafruit_neokeytrinkey_m0.build.core=arduino
-adafruit_neokeytrinkey_m0.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_NEOKEYTRINKEY_M0 -D__SAMD21E18A__ -DARM_MATH_CM0PLUS {build.usb_flags}
+adafruit_neokeytrinkey_m0.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_NEOKEYTRINKEY_M0 -D__SAMD21E18A__ -DARM_MATH_CM0PLUS -DADAFRUIT_ARCH_SAMD {build.usb_flags}
 adafruit_neokeytrinkey_m0.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_neokeytrinkey_m0.build.openocdscript=openocd_scripts/neokeytrinkey_m0.cfg
 adafruit_neokeytrinkey_m0.build.variant=neokeytrinkey_m0
@@ -546,7 +546,7 @@ adafruit_slidetrinkey_m0.build.usb_product="Slide Trinkey M0"
 adafruit_slidetrinkey_m0.build.usb_manufacturer="Adafruit"
 adafruit_slidetrinkey_m0.build.board=SLIDETRINKEY_M0
 adafruit_slidetrinkey_m0.build.core=arduino
-adafruit_slidetrinkey_m0.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_SLIDETRINKEY_M0 -D__SAMD21E18A__ -DARM_MATH_CM0PLUS {build.usb_flags}
+adafruit_slidetrinkey_m0.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_SLIDETRINKEY_M0 -D__SAMD21E18A__ -DARM_MATH_CM0PLUS -DADAFRUIT_ARCH_SAMD {build.usb_flags}
 adafruit_slidetrinkey_m0.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_slidetrinkey_m0.build.openocdscript=openocd_scripts/slidetrinkey_m0.cfg
 adafruit_slidetrinkey_m0.build.variant=slidetrinkey_m0
@@ -594,7 +594,7 @@ adafruit_proxlighttrinkey_m0.build.usb_product="ProxLight Trinkey M0"
 adafruit_proxlighttrinkey_m0.build.usb_manufacturer="Adafruit"
 adafruit_proxlighttrinkey_m0.build.board=PROXLIGHTTRINKEY_M0
 adafruit_proxlighttrinkey_m0.build.core=arduino
-adafruit_proxlighttrinkey_m0.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_PROXLIGHTTRINKEY_M0 -D__SAMD21E18A__ -DARM_MATH_CM0PLUS {build.usb_flags}
+adafruit_proxlighttrinkey_m0.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_PROXLIGHTTRINKEY_M0 -D__SAMD21E18A__ -DARM_MATH_CM0PLUS -DADAFRUIT_ARCH_SAMD {build.usb_flags}
 adafruit_proxlighttrinkey_m0.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_proxlighttrinkey_m0.build.openocdscript=openocd_scripts/proxlighttrinkey_m0.cfg
 adafruit_proxlighttrinkey_m0.build.variant=proxlighttrinkey_m0
@@ -643,7 +643,7 @@ adafruit_itsybitsy_m0.build.usb_product="ItsyBitsy M0 Express"
 adafruit_itsybitsy_m0.build.usb_manufacturer="Adafruit"
 adafruit_itsybitsy_m0.build.board=ITSYBITSY_M0
 adafruit_itsybitsy_m0.build.core=arduino
-adafruit_itsybitsy_m0.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_ITSYBITSY_M0 -D__SAMD21G18A__ -DARM_MATH_CM0PLUS {build.usb_flags}
+adafruit_itsybitsy_m0.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_ITSYBITSY_M0 -D__SAMD21G18A__ -DARM_MATH_CM0PLUS -DADAFRUIT_ARCH_SAMD {build.usb_flags}
 adafruit_itsybitsy_m0.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_itsybitsy_m0.build.openocdscript=openocd_scripts/itsybitsy_m0.cfg
 adafruit_itsybitsy_m0.build.variant=itsybitsy_m0
@@ -690,7 +690,7 @@ adafruit_pirkey.build.usb_product="pIRKey"
 adafruit_pirkey.build.usb_manufacturer="Adafruit"
 adafruit_pirkey.build.board=PIRKEY
 adafruit_pirkey.build.core=arduino
-adafruit_pirkey.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_PIRKEY -D__SAMD21E18A__ -DARM_MATH_CM0PLUS {build.usb_flags}
+adafruit_pirkey.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_PIRKEY -D__SAMD21E18A__ -DARM_MATH_CM0PLUS -DADAFRUIT_ARCH_SAMD {build.usb_flags}
 adafruit_pirkey.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_pirkey.build.openocdscript=openocd_scripts/arduino_zero.cfg
 adafruit_pirkey.build.variant=pirkey
@@ -735,7 +735,7 @@ adafruit_hallowing.build.usb_product="Hallowing M0"
 adafruit_hallowing.build.usb_manufacturer="Adafruit"
 adafruit_hallowing.build.board=SAMD_HALLOWING
 adafruit_hallowing.build.core=arduino
-adafruit_hallowing.build.extra_flags=-DCRYSTALLESS -DARDUINO_SAMD_ZERO -DARDUINO_SAMD_HALLOWING_M0 -DARM_MATH_CM0PLUS -DADAFRUIT_HALLOWING -D__SAMD21G18A__ {build.usb_flags}
+adafruit_hallowing.build.extra_flags=-DCRYSTALLESS -DARDUINO_SAMD_ZERO -DARDUINO_SAMD_HALLOWING_M0 -DARM_MATH_CM0PLUS -DADAFRUIT_HALLOWING -D__SAMD21G18A__ -DADAFRUIT_ARCH_SAMD {build.usb_flags}
 adafruit_hallowing.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_hallowing.build.openocdscript=openocd_scripts/hallowing_m0_express.cfg
 adafruit_hallowing.build.variant=hallowing_m0_express
@@ -783,7 +783,7 @@ adafruit_crickit_m0.build.usb_product="Crickit M0"
 adafruit_crickit_m0.build.usb_manufacturer="Adafruit"
 adafruit_crickit_m0.build.board=CRICKIT_M0
 adafruit_crickit_m0.build.core=arduino
-adafruit_crickit_m0.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_CRICKIT_M0 -D__SAMD21G18A__ -DARM_MATH_CM0PLUS {build.usb_flags}
+adafruit_crickit_m0.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_CRICKIT_M0 -D__SAMD21G18A__ -DARM_MATH_CM0PLUS -DADAFRUIT_ARCH_SAMD {build.usb_flags}
 adafruit_crickit_m0.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_crickit_m0.build.openocdscript=openocd_scripts/crickit_m0.cfg
 adafruit_crickit_m0.build.variant=crickit_m0
@@ -829,7 +829,7 @@ adafruit_metro_m4.build.usb_product="Adafruit Metro M4"
 adafruit_metro_m4.build.usb_manufacturer="Adafruit LLC"
 adafruit_metro_m4.build.board=METRO_M4
 adafruit_metro_m4.build.core=arduino
-adafruit_metro_m4.build.extra_flags=-D__SAMD51J19A__ -DADAFRUIT_METRO_M4_EXPRESS -D__SAMD51__ {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+adafruit_metro_m4.build.extra_flags=-D__SAMD51J19A__ -DADAFRUIT_METRO_M4_EXPRESS -D__SAMD51__ -DADAFRUIT_ARCH_SAMD {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
 adafruit_metro_m4.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_metro_m4.build.openocdscript=openocd_scripts/arduino_zero.cfg
 adafruit_metro_m4.build.variant=metro_m4
@@ -895,7 +895,7 @@ adafruit_grandcentral_m4.build.usb_product="Adafruit Grand Central M4"
 adafruit_grandcentral_m4.build.usb_manufacturer="Adafruit LLC"
 adafruit_grandcentral_m4.build.board=GRAND_CENTRAL_M4
 adafruit_grandcentral_m4.build.core=arduino
-adafruit_grandcentral_m4.build.extra_flags=-D__SAMD51P20A__ -DADAFRUIT_GRAND_CENTRAL_M4 -D__SAMD51__ {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+adafruit_grandcentral_m4.build.extra_flags=-D__SAMD51P20A__ -DADAFRUIT_GRAND_CENTRAL_M4 -D__SAMD51__ -DADAFRUIT_ARCH_SAMD {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
 adafruit_grandcentral_m4.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_grandcentral_m4.build.openocdscript=openocd_scripts/arduino_zero.cfg
 adafruit_grandcentral_m4.build.variant=grand_central_m4
@@ -958,7 +958,7 @@ adafruit_itsybitsy_m4.build.usb_product="Adafruit ItsyBitsy M4"
 adafruit_itsybitsy_m4.build.usb_manufacturer="Adafruit LLC"
 adafruit_itsybitsy_m4.build.board=ITSYBITSY_M4
 adafruit_itsybitsy_m4.build.core=arduino
-adafruit_itsybitsy_m4.build.extra_flags=-D__SAMD51G19A__ -DADAFRUIT_ITSYBITSY_M4_EXPRESS -D__SAMD51__ {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -DCRYSTALLESS -mfloat-abi=hard -mfpu=fpv4-sp-d16
+adafruit_itsybitsy_m4.build.extra_flags=-D__SAMD51G19A__ -DADAFRUIT_ITSYBITSY_M4_EXPRESS -D__SAMD51__ -DADAFRUIT_ARCH_SAMD {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -DCRYSTALLESS -mfloat-abi=hard -mfpu=fpv4-sp-d16
 adafruit_itsybitsy_m4.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_itsybitsy_m4.build.openocdscript=openocd_scripts/arduino_zero.cfg
 adafruit_itsybitsy_m4.build.variant=itsybitsy_m4
@@ -1021,7 +1021,7 @@ adafruit_feather_m4.build.usb_product="Adafruit Feather M4"
 adafruit_feather_m4.build.usb_manufacturer="Adafruit LLC"
 adafruit_feather_m4.build.board=FEATHER_M4
 adafruit_feather_m4.build.core=arduino
-adafruit_feather_m4.build.extra_flags=-D__SAMD51J19A__ -DADAFRUIT_FEATHER_M4_EXPRESS -D__SAMD51__ {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+adafruit_feather_m4.build.extra_flags=-D__SAMD51J19A__ -DADAFRUIT_FEATHER_M4_EXPRESS -D__SAMD51__ -DADAFRUIT_ARCH_SAMD {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
 adafruit_feather_m4.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_feather_m4.build.openocdscript=openocd_scripts/arduino_zero.cfg
 adafruit_feather_m4.build.variant=feather_m4
@@ -1030,7 +1030,7 @@ adafruit_feather_m4.build.vid=0x239A
 adafruit_feather_m4.build.pid=0x8022
 adafruit_feather_m4.bootloader.tool=openocd
 adafruit_feather_m4.bootloader.file=featherM4/bootloader-feather_m4-v2.0.0-adafruit.5.bin
-adafruit_feather_m4.compiler.arm.cmsis.ldflags="-L{runtime.tools.CMSIS-5.4.0.path}/CMSIS/Lib/GCC/" "-L{build.variant.path}" -larm_cortexM4lf_math -mfloat-abi=hard -mfpu=fpv4-sp-d16 
+adafruit_feather_m4.compiler.arm.cmsis.ldflags="-L{runtime.tools.CMSIS-5.4.0.path}/CMSIS/Lib/GCC/" "-L{build.variant.path}" -larm_cortexM4lf_math -mfloat-abi=hard -mfpu=fpv4-sp-d16
 adafruit_feather_m4.menu.cache.on=Enabled
 adafruit_feather_m4.menu.cache.on.build.cache_flags=-DENABLE_CACHE
 adafruit_feather_m4.menu.cache.off=Disabled
@@ -1084,7 +1084,7 @@ adafruit_feather_m4_can.build.usb_product="Adafruit Feather M4 CAN"
 adafruit_feather_m4_can.build.usb_manufacturer="Adafruit LLC"
 adafruit_feather_m4_can.build.board=FEATHER_M4_CAN
 adafruit_feather_m4_can.build.core=arduino
-adafruit_feather_m4_can.build.extra_flags=-D__SAME51J19A__ -DADAFRUIT_FEATHER_M4_EXPRESS -DADAFRUIT_FEATHER_M4_CAN -D__SAMD51__ {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+adafruit_feather_m4_can.build.extra_flags=-D__SAME51J19A__ -DADAFRUIT_FEATHER_M4_EXPRESS -DADAFRUIT_FEATHER_M4_CAN -D__SAMD51__ -DADAFRUIT_ARCH_SAMD {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
 adafruit_feather_m4_can.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_feather_m4_can.build.openocdscript=openocd_scripts/arduino_zero.cfg
 adafruit_feather_m4_can.build.variant=feather_m4_can
@@ -1150,7 +1150,7 @@ adafruit_trellis_m4.build.usb_product="Adafruit Trellis M4"
 adafruit_trellis_m4.build.usb_manufacturer="Adafruit LLC"
 adafruit_trellis_m4.build.board=TRELLIS_M4
 adafruit_trellis_m4.build.core=arduino
-adafruit_trellis_m4.build.extra_flags=-D__SAMD51G19A__ -DADAFRUIT_TRELLIS_M4_EXPRESS -D__SAMD51__ {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -DCRYSTALLESS -mfloat-abi=hard -mfpu=fpv4-sp-d16
+adafruit_trellis_m4.build.extra_flags=-D__SAMD51G19A__ -DADAFRUIT_TRELLIS_M4_EXPRESS -D__SAMD51__ -DADAFRUIT_ARCH_SAMD {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -DCRYSTALLESS -mfloat-abi=hard -mfpu=fpv4-sp-d16
 adafruit_trellis_m4.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_trellis_m4.build.openocdscript=openocd_scripts/arduino_zero.cfg
 adafruit_trellis_m4.build.variant=trellis_m4
@@ -1213,7 +1213,7 @@ adafruit_pyportal_m4.build.usb_product="Adafruit PyPortal M4"
 adafruit_pyportal_m4.build.usb_manufacturer="Adafruit LLC"
 adafruit_pyportal_m4.build.board=PYPORTAL_M4
 adafruit_pyportal_m4.build.core=arduino
-adafruit_pyportal_m4.build.extra_flags=-D__SAMD51J20A__ -DADAFRUIT_PYPORTAL -DCRYSTALLESS -D__SAMD51__ {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+adafruit_pyportal_m4.build.extra_flags=-D__SAMD51J20A__ -DADAFRUIT_PYPORTAL -DCRYSTALLESS -D__SAMD51__ -DADAFRUIT_ARCH_SAMD {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
 adafruit_pyportal_m4.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_pyportal_m4.build.openocdscript=openocd_scripts/arduino_zero.cfg
 adafruit_pyportal_m4.build.variant=pyportal_m4
@@ -1276,7 +1276,7 @@ adafruit_pyportal_m4_titano.build.usb_product="Adafruit PyPortal M4 Titano"
 adafruit_pyportal_m4_titano.build.usb_manufacturer="Adafruit LLC"
 adafruit_pyportal_m4_titano.build.board=PYPORTAL_M4_TITANO
 adafruit_pyportal_m4_titano.build.core=arduino
-adafruit_pyportal_m4_titano.build.extra_flags=-D__SAMD51J20A__ -DADAFRUIT_PYPORTAL_M4_TITANO -DCRYSTALLESS -D__SAMD51__ {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+adafruit_pyportal_m4_titano.build.extra_flags=-D__SAMD51J20A__ -DADAFRUIT_PYPORTAL_M4_TITANO -DCRYSTALLESS -D__SAMD51__ -DADAFRUIT_ARCH_SAMD {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
 adafruit_pyportal_m4_titano.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_pyportal_m4_titano.build.openocdscript=openocd_scripts/arduino_zero.cfg
 adafruit_pyportal_m4_titano.build.variant=pyportal_m4_titano
@@ -1341,7 +1341,7 @@ adafruit_pybadge_m4.build.usb_product="Adafruit pyBadge M4"
 adafruit_pybadge_m4.build.usb_manufacturer="Adafruit LLC"
 adafruit_pybadge_m4.build.board=PYBADGE_M4
 adafruit_pybadge_m4.build.core=arduino
-adafruit_pybadge_m4.build.extra_flags=-D__SAMD51J19A__ -DADAFRUIT_PYBADGE_M4_EXPRESS -DCRYSTALLESS -D__SAMD51__ {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+adafruit_pybadge_m4.build.extra_flags=-D__SAMD51J19A__ -DADAFRUIT_PYBADGE_M4_EXPRESS -DCRYSTALLESS -D__SAMD51__ -DADAFRUIT_ARCH_SAMD {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
 adafruit_pybadge_m4.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_pybadge_m4.build.openocdscript=openocd_scripts/arduino_zero.cfg
 adafruit_pybadge_m4.build.variant=pybadge_m4
@@ -1405,7 +1405,7 @@ adafruit_metro_m4_airliftlite.build.usb_product="Adafruit Metro M4 Airlift Lite"
 adafruit_metro_m4_airliftlite.build.usb_manufacturer="Adafruit LLC"
 adafruit_metro_m4_airliftlite.build.board=METRO_M4_AIRLIFT_LITE
 adafruit_metro_m4_airliftlite.build.core=arduino
-adafruit_metro_m4_airliftlite.build.extra_flags=-D__SAMD51J19A__ -DADAFRUIT_METRO_M4_AIRLIFT_LITE -D__SAMD51__ {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+adafruit_metro_m4_airliftlite.build.extra_flags=-D__SAMD51J19A__ -DADAFRUIT_METRO_M4_AIRLIFT_LITE -D__SAMD51__ -DADAFRUIT_ARCH_SAMD {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
 adafruit_metro_m4_airliftlite.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_metro_m4_airliftlite.build.openocdscript=openocd_scripts/arduino_zero.cfg
 adafruit_metro_m4_airliftlite.build.variant=metro_m4_airlift
@@ -1470,7 +1470,7 @@ adafruit_pygamer_m4.build.usb_product="Adafruit PyGamer M4"
 adafruit_pygamer_m4.build.usb_manufacturer="Adafruit LLC"
 adafruit_pygamer_m4.build.board=PYGAMER_M4
 adafruit_pygamer_m4.build.core=arduino
-adafruit_pygamer_m4.build.extra_flags=-D__SAMD51J19A__ -DADAFRUIT_PYGAMER_M4_EXPRESS -DCRYSTALLESS -D__SAMD51__ {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+adafruit_pygamer_m4.build.extra_flags=-D__SAMD51J19A__ -DADAFRUIT_PYGAMER_M4_EXPRESS -DCRYSTALLESS -D__SAMD51__ -DADAFRUIT_ARCH_SAMD {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
 adafruit_pygamer_m4.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_pygamer_m4.build.openocdscript=openocd_scripts/arduino_zero.cfg
 adafruit_pygamer_m4.build.variant=pygamer_m4
@@ -1534,7 +1534,7 @@ adafruit_pygamer_advance_m4.build.usb_product="Adafruit PyGamer Advance M4"
 adafruit_pygamer_advance_m4.build.usb_manufacturer="Adafruit LLC"
 adafruit_pygamer_advance_m4.build.board=PYGAMER_ADVANCE_M4
 adafruit_pygamer_advance_m4.build.core=arduino
-adafruit_pygamer_advance_m4.build.extra_flags=-D__SAMD51J20A__ -DADAFRUIT_PYGAMER_ADVANCE_M4_EXPRESS -DCRYSTALLESS -D__SAMD51__ {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+adafruit_pygamer_advance_m4.build.extra_flags=-D__SAMD51J20A__ -DADAFRUIT_PYGAMER_ADVANCE_M4_EXPRESS -DCRYSTALLESS -D__SAMD51__ -DADAFRUIT_ARCH_SAMD {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
 adafruit_pygamer_advance_m4.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_pygamer_advance_m4.build.openocdscript=openocd_scripts/arduino_zero.cfg
 adafruit_pygamer_advance_m4.build.variant=pygamer_advance_m4
@@ -1600,7 +1600,7 @@ adafruit_pybadge_airlift_m4.build.usb_product="Adafruit pyBadge AirLift M4"
 adafruit_pybadge_airlift_m4.build.usb_manufacturer="Adafruit LLC"
 adafruit_pybadge_airlift_m4.build.board=PYBADGE_AIRLIFT_M4
 adafruit_pybadge_airlift_m4.build.core=arduino
-adafruit_pybadge_airlift_m4.build.extra_flags=-D__SAMD51J20A__ -DADAFRUIT_PYBADGE_AIRLIFT_M4 -DCRYSTALLESS -D__SAMD51__ {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+adafruit_pybadge_airlift_m4.build.extra_flags=-D__SAMD51J20A__ -DADAFRUIT_PYBADGE_AIRLIFT_M4 -DCRYSTALLESS -D__SAMD51__ -DADAFRUIT_ARCH_SAMD {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
 adafruit_pybadge_airlift_m4.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_pybadge_airlift_m4.build.openocdscript=openocd_scripts/arduino_zero.cfg
 adafruit_pybadge_airlift_m4.build.variant=pybadge_airlift_m4
@@ -1666,7 +1666,7 @@ adafruit_monster_m4sk.build.usb_product="Adafruit MONSTER M4SK"
 adafruit_monster_m4sk.build.usb_manufacturer="Adafruit LLC"
 adafruit_monster_m4sk.build.board=MONSTER_M4SK
 adafruit_monster_m4sk.build.core=arduino
-adafruit_monster_m4sk.build.extra_flags=-D__SAMD51G19A__ -DADAFRUIT_MONSTER_M4SK_EXPRESS -DCRYSTALLESS -D__SAMD51__ {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+adafruit_monster_m4sk.build.extra_flags=-D__SAMD51G19A__ -DADAFRUIT_MONSTER_M4SK_EXPRESS -DCRYSTALLESS -D__SAMD51__ -DADAFRUIT_ARCH_SAMD {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
 adafruit_monster_m4sk.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_monster_m4sk.build.openocdscript=openocd_scripts/arduino_zero.cfg
 adafruit_monster_m4sk.build.variant=monster_m4sk
@@ -1732,7 +1732,7 @@ adafruit_hallowing_m4.build.usb_product="Adafruit Hallowing M4"
 adafruit_hallowing_m4.build.usb_manufacturer="Adafruit LLC"
 adafruit_hallowing_m4.build.board=HALLOWING_M4
 adafruit_hallowing_m4.build.core=arduino
-adafruit_hallowing_m4.build.extra_flags=-D__SAMD51J19A__ -DADAFRUIT_HALLOWING_M4_EXPRESS -DCRYSTALLESS -D__SAMD51__ {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+adafruit_hallowing_m4.build.extra_flags=-D__SAMD51J19A__ -DADAFRUIT_HALLOWING_M4_EXPRESS -DCRYSTALLESS -D__SAMD51__ -DADAFRUIT_ARCH_SAMD {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
 adafruit_hallowing_m4.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_hallowing_m4.build.openocdscript=openocd_scripts/arduino_zero.cfg
 adafruit_hallowing_m4.build.variant=hallowing_m4
@@ -1797,7 +1797,7 @@ adafruit_matrixportal_m4.build.usb_product="Adafruit Matrix Portal M4"
 adafruit_matrixportal_m4.build.usb_manufacturer="Adafruit LLC"
 adafruit_matrixportal_m4.build.board=MATRIXPORTAL_M4
 adafruit_matrixportal_m4.build.core=arduino
-adafruit_matrixportal_m4.build.extra_flags=-D__SAMD51J19A__ -DADAFRUIT_MATRIXPORTAL_M4_EXPRESS -DCRYSTALLESS -D__SAMD51__ {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+adafruit_matrixportal_m4.build.extra_flags=-D__SAMD51J19A__ -DADAFRUIT_MATRIXPORTAL_M4_EXPRESS -DCRYSTALLESS -D__SAMD51__ -DADAFRUIT_ARCH_SAMD {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
 adafruit_matrixportal_m4.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_matrixportal_m4.build.openocdscript=openocd_scripts/arduino_zero.cfg
 adafruit_matrixportal_m4.build.variant=matrixportal_m4
@@ -1860,7 +1860,7 @@ adafruit_blm_badge.build.usb_product="BLM Badge"
 adafruit_blm_badge.build.usb_manufacturer="Adafruit"
 adafruit_blm_badge.build.board=BLM_BADGE_M0
 adafruit_blm_badge.build.core=arduino
-adafruit_blm_badge.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_BLM_BADGE -D__SAMD21E18A__ -DARDUINO_SAMD_ZERO -DARM_MATH_CM0PLUS {build.usb_flags}
+adafruit_blm_badge.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_BLM_BADGE -D__SAMD21E18A__ -DARDUINO_SAMD_ZERO -DARM_MATH_CM0PLUS -DADAFRUIT_ARCH_SAMD {build.usb_flags}
 adafruit_blm_badge.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_blm_badge.build.openocdscript=openocd_scripts/=blm_badge.cfg
 adafruit_blm_badge.build.variant=blm_badge

--- a/boards.txt
+++ b/boards.txt
@@ -43,7 +43,7 @@ adafruit_feather_m0.build.usb_product="Feather M0"
 adafruit_feather_m0.build.usb_manufacturer="Adafruit"
 adafruit_feather_m0.build.board=SAMD_ZERO
 adafruit_feather_m0.build.core=arduino
-adafruit_feather_m0.build.extra_flags=-DARDUINO_SAMD_ZERO -DARM_MATH_CM0PLUS -DADAFRUIT_FEATHER_M0 -D__SAMD21G18A__ -DADAFRUIT_ARCH_SAMD {build.usb_flags}
+adafruit_feather_m0.build.extra_flags=-DARDUINO_SAMD_ZERO -DARM_MATH_CM0PLUS -DADAFRUIT_FEATHER_M0 -D__SAMD21G18A__ {build.usb_flags}
 adafruit_feather_m0.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_feather_m0.build.openocdscript=openocd_scripts/feather_m0.cfg
 adafruit_feather_m0.build.variant=feather_m0
@@ -90,7 +90,7 @@ adafruit_feather_m0_express.build.usb_product="Feather M0 Express"
 adafruit_feather_m0_express.build.usb_manufacturer="Adafruit"
 adafruit_feather_m0_express.build.board=SAMD_FEATHER_M0_EXPRESS
 adafruit_feather_m0_express.build.core=arduino
-adafruit_feather_m0_express.build.extra_flags=-DARDUINO_SAMD_ZERO -DARDUINO_SAMD_FEATHER_M0 -DARM_MATH_CM0PLUS -DADAFRUIT_FEATHER_M0_EXPRESS -D__SAMD21G18A__ -DADAFRUIT_ARCH_SAMD {build.usb_flags}
+adafruit_feather_m0_express.build.extra_flags=-DARDUINO_SAMD_ZERO -DARDUINO_SAMD_FEATHER_M0 -DARM_MATH_CM0PLUS -DADAFRUIT_FEATHER_M0_EXPRESS -D__SAMD21G18A__ {build.usb_flags}
 adafruit_feather_m0_express.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_feather_m0_express.build.openocdscript=openocd_scripts/feather_m0_express.cfg
 adafruit_feather_m0_express.build.variant=feather_m0_express
@@ -134,7 +134,7 @@ adafruit_feather_m0_express.menu.debug.on.build.flags.debug=-g
 #adafruit_radio_m0.build.usb_manufacturer="Adafruit"
 #adafruit_radio_m0.build.board=SAMD_ZERO
 #adafruit_radio_m0.build.core=arduino
-#adafruit_radio_m0.build.extra_flags=-D__SAMR21G18A__ -DARM_MATH_CM0PLUS -DADAFRUIT_ARCH_SAMD {build.usb_flags}
+#adafruit_radio_m0.build.extra_flags=-D__SAMR21G18A__ -DARM_MATH_CM0PLUS {build.usb_flags}
 #adafruit_radio_m0.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 #adafruit_radio_m0.build.openocdscript=openocd_scripts/zero_radio.cfg
 #adafruit_radio_m0.build.variant=zero_radio
@@ -164,7 +164,7 @@ adafruit_metro_m0.build.usb_product="Metro M0 Express"
 adafruit_metro_m0.build.usb_manufacturer="Adafruit"
 adafruit_metro_m0.build.board=SAMD_ZERO
 adafruit_metro_m0.build.core=arduino
-adafruit_metro_m0.build.extra_flags=-D__SAMD21G18A__ -DARDUINO_SAMD_ZERO -DARM_MATH_CM0PLUS -DADAFRUIT_METRO_M0_EXPRESS -DADAFRUIT_ARCH_SAMD {build.usb_flags}
+adafruit_metro_m0.build.extra_flags=-D__SAMD21G18A__ -DARDUINO_SAMD_ZERO -DARM_MATH_CM0PLUS -DADAFRUIT_METRO_M0_EXPRESS {build.usb_flags}
 adafruit_metro_m0.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_metro_m0.build.openocdscript=openocd_scripts/metro_m0.cfg
 adafruit_metro_m0.build.variant=metro_m0
@@ -211,7 +211,7 @@ adafruit_circuitplayground_m0.build.usb_product="Circuit Playground Express"
 adafruit_circuitplayground_m0.build.usb_manufacturer="Adafruit"
 adafruit_circuitplayground_m0.build.board=SAMD_CIRCUITPLAYGROUND_EXPRESS
 adafruit_circuitplayground_m0.build.core=arduino
-adafruit_circuitplayground_m0.build.extra_flags=-DCRYSTALLESS -DARDUINO_SAMD_ZERO -D__SAMD21G18A__ -DARM_MATH_CM0PLUS -DADAFRUIT_CIRCUITPLAYGROUND_M0 -DADAFRUIT_ARCH_SAMD {build.usb_flags}
+adafruit_circuitplayground_m0.build.extra_flags=-DCRYSTALLESS -DARDUINO_SAMD_ZERO -D__SAMD21G18A__ -DARM_MATH_CM0PLUS -DADAFRUIT_CIRCUITPLAYGROUND_M0 {build.usb_flags}
 adafruit_circuitplayground_m0.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_circuitplayground_m0.build.openocdscript=openocd_scripts/circuit_play.cfg
 adafruit_circuitplayground_m0.build.variant=circuitplay
@@ -258,7 +258,7 @@ adafruit_gemma_m0.build.usb_product="Gemma M0"
 adafruit_gemma_m0.build.usb_manufacturer="Adafruit"
 adafruit_gemma_m0.build.board=GEMMA_M0
 adafruit_gemma_m0.build.core=arduino
-adafruit_gemma_m0.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_GEMMA_M0 -D__SAMD21E18A__ -DARM_MATH_CM0PLUS -DADAFRUIT_ARCH_SAMD {build.usb_flags}
+adafruit_gemma_m0.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_GEMMA_M0 -D__SAMD21E18A__ -DARM_MATH_CM0PLUS {build.usb_flags}
 adafruit_gemma_m0.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_gemma_m0.build.openocdscript=openocd_scripts/gemma_m0.cfg
 adafruit_gemma_m0.build.variant=gemma_m0
@@ -304,7 +304,7 @@ adafruit_trinket_m0.build.usb_product="Trinket M0"
 adafruit_trinket_m0.build.usb_manufacturer="Adafruit"
 adafruit_trinket_m0.build.board=TRINKET_M0
 adafruit_trinket_m0.build.core=arduino
-adafruit_trinket_m0.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_TRINKET_M0 -D__SAMD21E18A__ -DARM_MATH_CM0PLUS -DADAFRUIT_ARCH_SAMD {build.usb_flags}
+adafruit_trinket_m0.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_TRINKET_M0 -D__SAMD21E18A__ -DARM_MATH_CM0PLUS {build.usb_flags}
 adafruit_trinket_m0.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_trinket_m0.build.openocdscript=openocd_scripts/trinket_m0.cfg
 adafruit_trinket_m0.build.variant=trinket_m0
@@ -352,7 +352,7 @@ adafruit_qtpy_m0.build.usb_product="QT Py M0"
 adafruit_qtpy_m0.build.usb_manufacturer="Adafruit"
 adafruit_qtpy_m0.build.board=QTPY_M0
 adafruit_qtpy_m0.build.core=arduino
-adafruit_qtpy_m0.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_QTPY_M0 -D__SAMD21E18A__ -DARM_MATH_CM0PLUS -DADAFRUIT_ARCH_SAMD {build.usb_flags}
+adafruit_qtpy_m0.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_QTPY_M0 -D__SAMD21E18A__ -DARM_MATH_CM0PLUS {build.usb_flags}
 adafruit_qtpy_m0.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_qtpy_m0.build.openocdscript=openocd_scripts/trinket_m0.cfg
 adafruit_qtpy_m0.build.variant=qtpy_m0
@@ -400,7 +400,7 @@ adafruit_neotrinkey_m0.build.usb_product="NeoPixel Trinkey M0"
 adafruit_neotrinkey_m0.build.usb_manufacturer="Adafruit"
 adafruit_neotrinkey_m0.build.board=NEOTRINKEY_M0
 adafruit_neotrinkey_m0.build.core=arduino
-adafruit_neotrinkey_m0.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_NEOTRINKEY_M0 -D__SAMD21E18A__ -DARM_MATH_CM0PLUS -DADAFRUIT_ARCH_SAMD {build.usb_flags}
+adafruit_neotrinkey_m0.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_NEOTRINKEY_M0 -D__SAMD21E18A__ -DARM_MATH_CM0PLUS {build.usb_flags}
 adafruit_neotrinkey_m0.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_neotrinkey_m0.build.openocdscript=openocd_scripts/neotrinkey_m0.cfg
 adafruit_neotrinkey_m0.build.variant=neotrinkey_m0
@@ -448,7 +448,7 @@ adafruit_rotarytrinkey_m0.build.usb_product="Rotary Trinkey M0"
 adafruit_rotarytrinkey_m0.build.usb_manufacturer="Adafruit"
 adafruit_rotarytrinkey_m0.build.board=ROTARYTRINKEY_M0
 adafruit_rotarytrinkey_m0.build.core=arduino
-adafruit_rotarytrinkey_m0.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_ROTARYTRINKEY_M0 -D__SAMD21E18A__ -DARM_MATH_CM0PLUS -DADAFRUIT_ARCH_SAMD {build.usb_flags}
+adafruit_rotarytrinkey_m0.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_ROTARYTRINKEY_M0 -D__SAMD21E18A__ -DARM_MATH_CM0PLUS {build.usb_flags}
 adafruit_rotarytrinkey_m0.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_rotarytrinkey_m0.build.openocdscript=openocd_scripts/rotarytrinkey_m0.cfg
 adafruit_rotarytrinkey_m0.build.variant=rotarytrinkey_m0
@@ -496,7 +496,7 @@ adafruit_neokeytrinkey_m0.build.usb_product="NeoKey Trinkey M0"
 adafruit_neokeytrinkey_m0.build.usb_manufacturer="Adafruit"
 adafruit_neokeytrinkey_m0.build.board=NEOKEYTRINKEY_M0
 adafruit_neokeytrinkey_m0.build.core=arduino
-adafruit_neokeytrinkey_m0.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_NEOKEYTRINKEY_M0 -D__SAMD21E18A__ -DARM_MATH_CM0PLUS -DADAFRUIT_ARCH_SAMD {build.usb_flags}
+adafruit_neokeytrinkey_m0.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_NEOKEYTRINKEY_M0 -D__SAMD21E18A__ -DARM_MATH_CM0PLUS {build.usb_flags}
 adafruit_neokeytrinkey_m0.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_neokeytrinkey_m0.build.openocdscript=openocd_scripts/neokeytrinkey_m0.cfg
 adafruit_neokeytrinkey_m0.build.variant=neokeytrinkey_m0
@@ -546,7 +546,7 @@ adafruit_slidetrinkey_m0.build.usb_product="Slide Trinkey M0"
 adafruit_slidetrinkey_m0.build.usb_manufacturer="Adafruit"
 adafruit_slidetrinkey_m0.build.board=SLIDETRINKEY_M0
 adafruit_slidetrinkey_m0.build.core=arduino
-adafruit_slidetrinkey_m0.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_SLIDETRINKEY_M0 -D__SAMD21E18A__ -DARM_MATH_CM0PLUS -DADAFRUIT_ARCH_SAMD {build.usb_flags}
+adafruit_slidetrinkey_m0.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_SLIDETRINKEY_M0 -D__SAMD21E18A__ -DARM_MATH_CM0PLUS {build.usb_flags}
 adafruit_slidetrinkey_m0.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_slidetrinkey_m0.build.openocdscript=openocd_scripts/slidetrinkey_m0.cfg
 adafruit_slidetrinkey_m0.build.variant=slidetrinkey_m0
@@ -594,7 +594,7 @@ adafruit_proxlighttrinkey_m0.build.usb_product="ProxLight Trinkey M0"
 adafruit_proxlighttrinkey_m0.build.usb_manufacturer="Adafruit"
 adafruit_proxlighttrinkey_m0.build.board=PROXLIGHTTRINKEY_M0
 adafruit_proxlighttrinkey_m0.build.core=arduino
-adafruit_proxlighttrinkey_m0.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_PROXLIGHTTRINKEY_M0 -D__SAMD21E18A__ -DARM_MATH_CM0PLUS -DADAFRUIT_ARCH_SAMD {build.usb_flags}
+adafruit_proxlighttrinkey_m0.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_PROXLIGHTTRINKEY_M0 -D__SAMD21E18A__ -DARM_MATH_CM0PLUS {build.usb_flags}
 adafruit_proxlighttrinkey_m0.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_proxlighttrinkey_m0.build.openocdscript=openocd_scripts/proxlighttrinkey_m0.cfg
 adafruit_proxlighttrinkey_m0.build.variant=proxlighttrinkey_m0
@@ -643,7 +643,7 @@ adafruit_itsybitsy_m0.build.usb_product="ItsyBitsy M0 Express"
 adafruit_itsybitsy_m0.build.usb_manufacturer="Adafruit"
 adafruit_itsybitsy_m0.build.board=ITSYBITSY_M0
 adafruit_itsybitsy_m0.build.core=arduino
-adafruit_itsybitsy_m0.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_ITSYBITSY_M0 -D__SAMD21G18A__ -DARM_MATH_CM0PLUS -DADAFRUIT_ARCH_SAMD {build.usb_flags}
+adafruit_itsybitsy_m0.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_ITSYBITSY_M0 -D__SAMD21G18A__ -DARM_MATH_CM0PLUS {build.usb_flags}
 adafruit_itsybitsy_m0.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_itsybitsy_m0.build.openocdscript=openocd_scripts/itsybitsy_m0.cfg
 adafruit_itsybitsy_m0.build.variant=itsybitsy_m0
@@ -690,7 +690,7 @@ adafruit_pirkey.build.usb_product="pIRKey"
 adafruit_pirkey.build.usb_manufacturer="Adafruit"
 adafruit_pirkey.build.board=PIRKEY
 adafruit_pirkey.build.core=arduino
-adafruit_pirkey.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_PIRKEY -D__SAMD21E18A__ -DARM_MATH_CM0PLUS -DADAFRUIT_ARCH_SAMD {build.usb_flags}
+adafruit_pirkey.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_PIRKEY -D__SAMD21E18A__ -DARM_MATH_CM0PLUS {build.usb_flags}
 adafruit_pirkey.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_pirkey.build.openocdscript=openocd_scripts/arduino_zero.cfg
 adafruit_pirkey.build.variant=pirkey
@@ -735,7 +735,7 @@ adafruit_hallowing.build.usb_product="Hallowing M0"
 adafruit_hallowing.build.usb_manufacturer="Adafruit"
 adafruit_hallowing.build.board=SAMD_HALLOWING
 adafruit_hallowing.build.core=arduino
-adafruit_hallowing.build.extra_flags=-DCRYSTALLESS -DARDUINO_SAMD_ZERO -DARDUINO_SAMD_HALLOWING_M0 -DARM_MATH_CM0PLUS -DADAFRUIT_HALLOWING -D__SAMD21G18A__ -DADAFRUIT_ARCH_SAMD {build.usb_flags}
+adafruit_hallowing.build.extra_flags=-DCRYSTALLESS -DARDUINO_SAMD_ZERO -DARDUINO_SAMD_HALLOWING_M0 -DARM_MATH_CM0PLUS -DADAFRUIT_HALLOWING -D__SAMD21G18A__ {build.usb_flags}
 adafruit_hallowing.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_hallowing.build.openocdscript=openocd_scripts/hallowing_m0_express.cfg
 adafruit_hallowing.build.variant=hallowing_m0_express
@@ -783,7 +783,7 @@ adafruit_crickit_m0.build.usb_product="Crickit M0"
 adafruit_crickit_m0.build.usb_manufacturer="Adafruit"
 adafruit_crickit_m0.build.board=CRICKIT_M0
 adafruit_crickit_m0.build.core=arduino
-adafruit_crickit_m0.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_CRICKIT_M0 -D__SAMD21G18A__ -DARM_MATH_CM0PLUS -DADAFRUIT_ARCH_SAMD {build.usb_flags}
+adafruit_crickit_m0.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_CRICKIT_M0 -D__SAMD21G18A__ -DARM_MATH_CM0PLUS {build.usb_flags}
 adafruit_crickit_m0.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_crickit_m0.build.openocdscript=openocd_scripts/crickit_m0.cfg
 adafruit_crickit_m0.build.variant=crickit_m0
@@ -829,7 +829,7 @@ adafruit_metro_m4.build.usb_product="Adafruit Metro M4"
 adafruit_metro_m4.build.usb_manufacturer="Adafruit LLC"
 adafruit_metro_m4.build.board=METRO_M4
 adafruit_metro_m4.build.core=arduino
-adafruit_metro_m4.build.extra_flags=-D__SAMD51J19A__ -DADAFRUIT_METRO_M4_EXPRESS -D__SAMD51__ -DADAFRUIT_ARCH_SAMD {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+adafruit_metro_m4.build.extra_flags=-D__SAMD51J19A__ -DADAFRUIT_METRO_M4_EXPRESS -D__SAMD51__ {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
 adafruit_metro_m4.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_metro_m4.build.openocdscript=openocd_scripts/arduino_zero.cfg
 adafruit_metro_m4.build.variant=metro_m4
@@ -895,7 +895,7 @@ adafruit_grandcentral_m4.build.usb_product="Adafruit Grand Central M4"
 adafruit_grandcentral_m4.build.usb_manufacturer="Adafruit LLC"
 adafruit_grandcentral_m4.build.board=GRAND_CENTRAL_M4
 adafruit_grandcentral_m4.build.core=arduino
-adafruit_grandcentral_m4.build.extra_flags=-D__SAMD51P20A__ -DADAFRUIT_GRAND_CENTRAL_M4 -D__SAMD51__ -DADAFRUIT_ARCH_SAMD {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+adafruit_grandcentral_m4.build.extra_flags=-D__SAMD51P20A__ -DADAFRUIT_GRAND_CENTRAL_M4 -D__SAMD51__ {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
 adafruit_grandcentral_m4.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_grandcentral_m4.build.openocdscript=openocd_scripts/arduino_zero.cfg
 adafruit_grandcentral_m4.build.variant=grand_central_m4
@@ -958,7 +958,7 @@ adafruit_itsybitsy_m4.build.usb_product="Adafruit ItsyBitsy M4"
 adafruit_itsybitsy_m4.build.usb_manufacturer="Adafruit LLC"
 adafruit_itsybitsy_m4.build.board=ITSYBITSY_M4
 adafruit_itsybitsy_m4.build.core=arduino
-adafruit_itsybitsy_m4.build.extra_flags=-D__SAMD51G19A__ -DADAFRUIT_ITSYBITSY_M4_EXPRESS -D__SAMD51__ -DADAFRUIT_ARCH_SAMD {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -DCRYSTALLESS -mfloat-abi=hard -mfpu=fpv4-sp-d16
+adafruit_itsybitsy_m4.build.extra_flags=-D__SAMD51G19A__ -DADAFRUIT_ITSYBITSY_M4_EXPRESS -D__SAMD51__ {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -DCRYSTALLESS -mfloat-abi=hard -mfpu=fpv4-sp-d16
 adafruit_itsybitsy_m4.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_itsybitsy_m4.build.openocdscript=openocd_scripts/arduino_zero.cfg
 adafruit_itsybitsy_m4.build.variant=itsybitsy_m4
@@ -1021,7 +1021,7 @@ adafruit_feather_m4.build.usb_product="Adafruit Feather M4"
 adafruit_feather_m4.build.usb_manufacturer="Adafruit LLC"
 adafruit_feather_m4.build.board=FEATHER_M4
 adafruit_feather_m4.build.core=arduino
-adafruit_feather_m4.build.extra_flags=-D__SAMD51J19A__ -DADAFRUIT_FEATHER_M4_EXPRESS -D__SAMD51__ -DADAFRUIT_ARCH_SAMD {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+adafruit_feather_m4.build.extra_flags=-D__SAMD51J19A__ -DADAFRUIT_FEATHER_M4_EXPRESS -D__SAMD51__ {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
 adafruit_feather_m4.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_feather_m4.build.openocdscript=openocd_scripts/arduino_zero.cfg
 adafruit_feather_m4.build.variant=feather_m4
@@ -1084,7 +1084,7 @@ adafruit_feather_m4_can.build.usb_product="Adafruit Feather M4 CAN"
 adafruit_feather_m4_can.build.usb_manufacturer="Adafruit LLC"
 adafruit_feather_m4_can.build.board=FEATHER_M4_CAN
 adafruit_feather_m4_can.build.core=arduino
-adafruit_feather_m4_can.build.extra_flags=-D__SAME51J19A__ -DADAFRUIT_FEATHER_M4_EXPRESS -DADAFRUIT_FEATHER_M4_CAN -D__SAMD51__ -DADAFRUIT_ARCH_SAMD {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+adafruit_feather_m4_can.build.extra_flags=-D__SAME51J19A__ -DADAFRUIT_FEATHER_M4_EXPRESS -DADAFRUIT_FEATHER_M4_CAN -D__SAMD51__ {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
 adafruit_feather_m4_can.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_feather_m4_can.build.openocdscript=openocd_scripts/arduino_zero.cfg
 adafruit_feather_m4_can.build.variant=feather_m4_can
@@ -1150,7 +1150,7 @@ adafruit_trellis_m4.build.usb_product="Adafruit Trellis M4"
 adafruit_trellis_m4.build.usb_manufacturer="Adafruit LLC"
 adafruit_trellis_m4.build.board=TRELLIS_M4
 adafruit_trellis_m4.build.core=arduino
-adafruit_trellis_m4.build.extra_flags=-D__SAMD51G19A__ -DADAFRUIT_TRELLIS_M4_EXPRESS -D__SAMD51__ -DADAFRUIT_ARCH_SAMD {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -DCRYSTALLESS -mfloat-abi=hard -mfpu=fpv4-sp-d16
+adafruit_trellis_m4.build.extra_flags=-D__SAMD51G19A__ -DADAFRUIT_TRELLIS_M4_EXPRESS -D__SAMD51__ {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -DCRYSTALLESS -mfloat-abi=hard -mfpu=fpv4-sp-d16
 adafruit_trellis_m4.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_trellis_m4.build.openocdscript=openocd_scripts/arduino_zero.cfg
 adafruit_trellis_m4.build.variant=trellis_m4
@@ -1213,7 +1213,7 @@ adafruit_pyportal_m4.build.usb_product="Adafruit PyPortal M4"
 adafruit_pyportal_m4.build.usb_manufacturer="Adafruit LLC"
 adafruit_pyportal_m4.build.board=PYPORTAL_M4
 adafruit_pyportal_m4.build.core=arduino
-adafruit_pyportal_m4.build.extra_flags=-D__SAMD51J20A__ -DADAFRUIT_PYPORTAL -DCRYSTALLESS -D__SAMD51__ -DADAFRUIT_ARCH_SAMD {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+adafruit_pyportal_m4.build.extra_flags=-D__SAMD51J20A__ -DADAFRUIT_PYPORTAL -DCRYSTALLESS -D__SAMD51__ {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
 adafruit_pyportal_m4.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_pyportal_m4.build.openocdscript=openocd_scripts/arduino_zero.cfg
 adafruit_pyportal_m4.build.variant=pyportal_m4
@@ -1276,7 +1276,7 @@ adafruit_pyportal_m4_titano.build.usb_product="Adafruit PyPortal M4 Titano"
 adafruit_pyportal_m4_titano.build.usb_manufacturer="Adafruit LLC"
 adafruit_pyportal_m4_titano.build.board=PYPORTAL_M4_TITANO
 adafruit_pyportal_m4_titano.build.core=arduino
-adafruit_pyportal_m4_titano.build.extra_flags=-D__SAMD51J20A__ -DADAFRUIT_PYPORTAL_M4_TITANO -DCRYSTALLESS -D__SAMD51__ -DADAFRUIT_ARCH_SAMD {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+adafruit_pyportal_m4_titano.build.extra_flags=-D__SAMD51J20A__ -DADAFRUIT_PYPORTAL_M4_TITANO -DCRYSTALLESS -D__SAMD51__ {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
 adafruit_pyportal_m4_titano.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_pyportal_m4_titano.build.openocdscript=openocd_scripts/arduino_zero.cfg
 adafruit_pyportal_m4_titano.build.variant=pyportal_m4_titano
@@ -1341,7 +1341,7 @@ adafruit_pybadge_m4.build.usb_product="Adafruit pyBadge M4"
 adafruit_pybadge_m4.build.usb_manufacturer="Adafruit LLC"
 adafruit_pybadge_m4.build.board=PYBADGE_M4
 adafruit_pybadge_m4.build.core=arduino
-adafruit_pybadge_m4.build.extra_flags=-D__SAMD51J19A__ -DADAFRUIT_PYBADGE_M4_EXPRESS -DCRYSTALLESS -D__SAMD51__ -DADAFRUIT_ARCH_SAMD {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+adafruit_pybadge_m4.build.extra_flags=-D__SAMD51J19A__ -DADAFRUIT_PYBADGE_M4_EXPRESS -DCRYSTALLESS -D__SAMD51__ {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
 adafruit_pybadge_m4.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_pybadge_m4.build.openocdscript=openocd_scripts/arduino_zero.cfg
 adafruit_pybadge_m4.build.variant=pybadge_m4
@@ -1405,7 +1405,7 @@ adafruit_metro_m4_airliftlite.build.usb_product="Adafruit Metro M4 Airlift Lite"
 adafruit_metro_m4_airliftlite.build.usb_manufacturer="Adafruit LLC"
 adafruit_metro_m4_airliftlite.build.board=METRO_M4_AIRLIFT_LITE
 adafruit_metro_m4_airliftlite.build.core=arduino
-adafruit_metro_m4_airliftlite.build.extra_flags=-D__SAMD51J19A__ -DADAFRUIT_METRO_M4_AIRLIFT_LITE -D__SAMD51__ -DADAFRUIT_ARCH_SAMD {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+adafruit_metro_m4_airliftlite.build.extra_flags=-D__SAMD51J19A__ -DADAFRUIT_METRO_M4_AIRLIFT_LITE -D__SAMD51__ {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
 adafruit_metro_m4_airliftlite.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_metro_m4_airliftlite.build.openocdscript=openocd_scripts/arduino_zero.cfg
 adafruit_metro_m4_airliftlite.build.variant=metro_m4_airlift
@@ -1470,7 +1470,7 @@ adafruit_pygamer_m4.build.usb_product="Adafruit PyGamer M4"
 adafruit_pygamer_m4.build.usb_manufacturer="Adafruit LLC"
 adafruit_pygamer_m4.build.board=PYGAMER_M4
 adafruit_pygamer_m4.build.core=arduino
-adafruit_pygamer_m4.build.extra_flags=-D__SAMD51J19A__ -DADAFRUIT_PYGAMER_M4_EXPRESS -DCRYSTALLESS -D__SAMD51__ -DADAFRUIT_ARCH_SAMD {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+adafruit_pygamer_m4.build.extra_flags=-D__SAMD51J19A__ -DADAFRUIT_PYGAMER_M4_EXPRESS -DCRYSTALLESS -D__SAMD51__ {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
 adafruit_pygamer_m4.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_pygamer_m4.build.openocdscript=openocd_scripts/arduino_zero.cfg
 adafruit_pygamer_m4.build.variant=pygamer_m4
@@ -1534,7 +1534,7 @@ adafruit_pygamer_advance_m4.build.usb_product="Adafruit PyGamer Advance M4"
 adafruit_pygamer_advance_m4.build.usb_manufacturer="Adafruit LLC"
 adafruit_pygamer_advance_m4.build.board=PYGAMER_ADVANCE_M4
 adafruit_pygamer_advance_m4.build.core=arduino
-adafruit_pygamer_advance_m4.build.extra_flags=-D__SAMD51J20A__ -DADAFRUIT_PYGAMER_ADVANCE_M4_EXPRESS -DCRYSTALLESS -D__SAMD51__ -DADAFRUIT_ARCH_SAMD {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+adafruit_pygamer_advance_m4.build.extra_flags=-D__SAMD51J20A__ -DADAFRUIT_PYGAMER_ADVANCE_M4_EXPRESS -DCRYSTALLESS -D__SAMD51__ {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
 adafruit_pygamer_advance_m4.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_pygamer_advance_m4.build.openocdscript=openocd_scripts/arduino_zero.cfg
 adafruit_pygamer_advance_m4.build.variant=pygamer_advance_m4
@@ -1600,7 +1600,7 @@ adafruit_pybadge_airlift_m4.build.usb_product="Adafruit pyBadge AirLift M4"
 adafruit_pybadge_airlift_m4.build.usb_manufacturer="Adafruit LLC"
 adafruit_pybadge_airlift_m4.build.board=PYBADGE_AIRLIFT_M4
 adafruit_pybadge_airlift_m4.build.core=arduino
-adafruit_pybadge_airlift_m4.build.extra_flags=-D__SAMD51J20A__ -DADAFRUIT_PYBADGE_AIRLIFT_M4 -DCRYSTALLESS -D__SAMD51__ -DADAFRUIT_ARCH_SAMD {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+adafruit_pybadge_airlift_m4.build.extra_flags=-D__SAMD51J20A__ -DADAFRUIT_PYBADGE_AIRLIFT_M4 -DCRYSTALLESS -D__SAMD51__ {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
 adafruit_pybadge_airlift_m4.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_pybadge_airlift_m4.build.openocdscript=openocd_scripts/arduino_zero.cfg
 adafruit_pybadge_airlift_m4.build.variant=pybadge_airlift_m4
@@ -1666,7 +1666,7 @@ adafruit_monster_m4sk.build.usb_product="Adafruit MONSTER M4SK"
 adafruit_monster_m4sk.build.usb_manufacturer="Adafruit LLC"
 adafruit_monster_m4sk.build.board=MONSTER_M4SK
 adafruit_monster_m4sk.build.core=arduino
-adafruit_monster_m4sk.build.extra_flags=-D__SAMD51G19A__ -DADAFRUIT_MONSTER_M4SK_EXPRESS -DCRYSTALLESS -D__SAMD51__ -DADAFRUIT_ARCH_SAMD {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+adafruit_monster_m4sk.build.extra_flags=-D__SAMD51G19A__ -DADAFRUIT_MONSTER_M4SK_EXPRESS -DCRYSTALLESS -D__SAMD51__ {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
 adafruit_monster_m4sk.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_monster_m4sk.build.openocdscript=openocd_scripts/arduino_zero.cfg
 adafruit_monster_m4sk.build.variant=monster_m4sk
@@ -1732,7 +1732,7 @@ adafruit_hallowing_m4.build.usb_product="Adafruit Hallowing M4"
 adafruit_hallowing_m4.build.usb_manufacturer="Adafruit LLC"
 adafruit_hallowing_m4.build.board=HALLOWING_M4
 adafruit_hallowing_m4.build.core=arduino
-adafruit_hallowing_m4.build.extra_flags=-D__SAMD51J19A__ -DADAFRUIT_HALLOWING_M4_EXPRESS -DCRYSTALLESS -D__SAMD51__ -DADAFRUIT_ARCH_SAMD {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+adafruit_hallowing_m4.build.extra_flags=-D__SAMD51J19A__ -DADAFRUIT_HALLOWING_M4_EXPRESS -DCRYSTALLESS -D__SAMD51__ {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
 adafruit_hallowing_m4.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_hallowing_m4.build.openocdscript=openocd_scripts/arduino_zero.cfg
 adafruit_hallowing_m4.build.variant=hallowing_m4
@@ -1797,7 +1797,7 @@ adafruit_matrixportal_m4.build.usb_product="Adafruit Matrix Portal M4"
 adafruit_matrixportal_m4.build.usb_manufacturer="Adafruit LLC"
 adafruit_matrixportal_m4.build.board=MATRIXPORTAL_M4
 adafruit_matrixportal_m4.build.core=arduino
-adafruit_matrixportal_m4.build.extra_flags=-D__SAMD51J19A__ -DADAFRUIT_MATRIXPORTAL_M4_EXPRESS -DCRYSTALLESS -D__SAMD51__ -DADAFRUIT_ARCH_SAMD {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+adafruit_matrixportal_m4.build.extra_flags=-D__SAMD51J19A__ -DADAFRUIT_MATRIXPORTAL_M4_EXPRESS -DCRYSTALLESS -D__SAMD51__ {build.usb_flags} -D__FPU_PRESENT -DARM_MATH_CM4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
 adafruit_matrixportal_m4.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_matrixportal_m4.build.openocdscript=openocd_scripts/arduino_zero.cfg
 adafruit_matrixportal_m4.build.variant=matrixportal_m4
@@ -1860,7 +1860,7 @@ adafruit_blm_badge.build.usb_product="BLM Badge"
 adafruit_blm_badge.build.usb_manufacturer="Adafruit"
 adafruit_blm_badge.build.board=BLM_BADGE_M0
 adafruit_blm_badge.build.core=arduino
-adafruit_blm_badge.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_BLM_BADGE -D__SAMD21E18A__ -DARDUINO_SAMD_ZERO -DARM_MATH_CM0PLUS -DADAFRUIT_ARCH_SAMD {build.usb_flags}
+adafruit_blm_badge.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_BLM_BADGE -D__SAMD21E18A__ -DARDUINO_SAMD_ZERO -DARM_MATH_CM0PLUS {build.usb_flags}
 adafruit_blm_badge.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
 adafruit_blm_badge.build.openocdscript=openocd_scripts/=blm_badge.cfg
 adafruit_blm_badge.build.variant=blm_badge

--- a/platform.txt
+++ b/platform.txt
@@ -91,13 +91,13 @@ build.usb_manufacturer="Unknown"
 # ----------------
 
 ## Compile c files
-recipe.c.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.c.flags} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.c.extra_flags} {build.extra_flags} {build.cache_flags}  {build.flags.debug} {build.flags.optimize} {build.flags.maxspi} {build.flags.maxqspi} {compiler.arm.cmsis.c.flags} {includes} "{source_file}" -o "{object_file}"
+recipe.c.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.c.flags} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} -DARDUINO_SAMD_ADAFRUIT {compiler.c.extra_flags} {build.extra_flags} {build.cache_flags}  {build.flags.debug} {build.flags.optimize} {build.flags.maxspi} {build.flags.maxqspi} {compiler.arm.cmsis.c.flags} {includes} "{source_file}" -o "{object_file}"
 
 ## Compile c++ files
-recipe.cpp.o.pattern="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {build.cache_flags} {build.flags.debug} {build.flags.optimize} {build.flags.maxspi} {build.flags.maxqspi} {build.extra_flags} {compiler.arm.cmsis.c.flags} {includes} "{source_file}" -o "{object_file}"
+recipe.cpp.o.pattern="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} -DARDUINO_SAMD_ADAFRUIT {compiler.cpp.extra_flags} {build.extra_flags} {build.cache_flags} {build.flags.debug} {build.flags.optimize} {build.flags.maxspi} {build.flags.maxqspi} {build.extra_flags} {compiler.arm.cmsis.c.flags} {includes} "{source_file}" -o "{object_file}"
 
 ## Compile S files
-recipe.S.o.pattern="{compiler.path}{compiler.S.cmd}" {compiler.S.flags} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.S.extra_flags} {build.extra_flags} {build.cache_flags} {compiler.arm.cmsis.c.flags} {includes} "{source_file}" -o "{object_file}"
+recipe.S.o.pattern="{compiler.path}{compiler.S.cmd}" {compiler.S.flags} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} -DARDUINO_SAMD_ADAFRUIT {compiler.S.extra_flags} {build.extra_flags} {build.cache_flags} {compiler.arm.cmsis.c.flags} {includes} "{source_file}" -o "{object_file}"
 
 ## Create archives
 # archive_file_path is needed for backwards compatibility with IDE 1.6.5 or older, IDE 1.6.6 or newer overrides this value


### PR DESCRIPTION
resolves #305 

I chose the macro ADAFRUIT_ARCH_SAMD as it seems most like using ARDUINO_ARCH_SAMD macro.

tested with 
```cpp
            #if defined (ADAFRUIT_ARCH_SAMD)
                // using the adafruit/ArduinoCore-samd repo
                #define printf_P Serial.printf
            #endif // defined (ADAFRUIT_ARCH_SAMD)
```
verified working on QT PY M0. I don't have any Arduino produced SAMD-based boards, but the compiler output (targetting the MKR WIFI 1010 board) doesn't show the `-DADAFRUIT_ARCH_SAMD` being passed as an extra flag.