### PR TITLE
Bugfix - waiting for first ADC read to complete after ADC enable.

### DIFF
--- a/cores/arduino/wiring_analog.c
+++ b/cores/arduino/wiring_analog.c
@@ -375,6 +375,9 @@ uint32_t analogRead(uint32_t pin)
   syncADC();
   ADC->SWTRIG.bit.START = 1;
 
+  // Waiting for the 1st conversion to complete
+  while (ADC->INTFLAG.bit.RESRDY == 0);
+
   // Clear the Data Ready flag
   ADC->INTFLAG.reg = ADC_INTFLAG_RESRDY;
 


### PR DESCRIPTION
See: https://www.omzlo.com/articles/your-arduino-samd21-adc-is-wrong-did-you-notice