### PR TITLE
set DRVSTR on the neopixel power pin.

### DIFF
--- a/variants/feather_m4_can/variant.cpp
+++ b/variants/feather_m4_can/variant.cpp
@@ -150,7 +150,12 @@ void SERCOM5_3_Handler()
 void initVariant(void) {
   // special initialization code just for us
 
+#ifdef PIN_NEOPIXEL_POWER
   // turn on neopixel
-  pinMode(7, OUTPUT);
-  digitalWrite(7, HIGH);
+  pinMode(PIN_NEOPIXEL_POWER, OUTPUT);
+  digitalWrite(PIN_NEOPIXEL_POWER, HIGH);
+  PortGroup *port = digitalPinToPort(PIN_NEOPIXEL_POWER);
+  uint32_t bitnum = g_APinDescription[PIN_NEOPIXEL_POWER].ulPin;
+  port->PINCFG[bitnum].bit.DRVSTR = 1;  // turn up neopixel power
+#endif
 }

--- a/variants/qtpy_m0/variant.cpp
+++ b/variants/qtpy_m0/variant.cpp
@@ -80,7 +80,12 @@ void SERCOM0_Handler()
 void initVariant(void) {
   // special initialization code just for us
 
+#ifdef PIN_NEOPIXEL_POWER
   // turn on neopixel
-  pinMode(12, OUTPUT);
-  digitalWrite(12, HIGH);
+  pinMode(PIN_NEOPIXEL_POWER, OUTPUT);
+  digitalWrite(PIN_NEOPIXEL_POWER, HIGH);
+  PortGroup *port = digitalPinToPort(PIN_NEOPIXEL_POWER);
+  uint32_t bitnum = g_APinDescription[PIN_NEOPIXEL_POWER].ulPin;
+  port->PINCFG[bitnum].bit.DRVSTR = 1;  // turn up neopixel power
+#endif
 }

--- a/variants/qtpy_m0/variant.h
+++ b/variants/qtpy_m0/variant.h
@@ -81,6 +81,7 @@ extern "C"
 #define PIN_LED              PIN_LED_13
 #define LED_BUILTIN          PIN_LED_13
 #define PIN_NEOPIXEL         (11u)
+#define PIN_NEOPIXEL_POWER   (12u)
 
 /*
  * Analog pins


### PR DESCRIPTION
https://github.com/adafruit/ArduinoCore-samd/issues/311

SAMD output pins are used to power the built-in neopixel on some boards, but the pins all default to low (2ma?) drive strength.  This is apparently insufficient and can cause color shifts.
This PR sets the DRVSTR bit in the port pin configuration, at the time the neopixel power is turned on in initVariant()
