### PR TITLE
add -Werror=return-type for all warning options

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -25,11 +25,11 @@ version=1.7.5
 # Compile variables
 # -----------------
 
-compiler.warning_flags=-w
-compiler.warning_flags.none=-w
-compiler.warning_flags.default=
-compiler.warning_flags.more=-Wall -Wno-expansion-to-defined
-compiler.warning_flags.all=-Wall -Wextra -Wno-expansion-to-defined
+compiler.warning_flags=-Werror=return-type
+compiler.warning_flags.none=-Werror=return-type
+compiler.warning_flags.default=-Werror=return-type
+compiler.warning_flags.more=-Wall -Werror=return-type -Wno-expansion-to-defined
+compiler.warning_flags.all=-Wall -Wextra -Werror=return-type -Wno-expansion-to-defined
 
 compiler.path={runtime.tools.arm-none-eabi-gcc.path}/bin/
 compiler.c.cmd=arm-none-eabi-gcc


### PR DESCRIPTION
Fix dangerous issue where the function declared with return value does not return at all. Which could cause mis-matched issue on the execution stack. Force this as an error for all compiler warning option. See also https://forums.adafruit.com/viewtopic.php?f=62&t=186839