### PR TITLE
Add defines for internal DotStar pins

### DIFF
--- a/variants/gemma_m0/variant.h
+++ b/variants/gemma_m0/variant.h
@@ -85,11 +85,11 @@ extern "C"
 #define PIN_LED3             PIN_LED_TXL
 #define LED_BUILTIN          PIN_LED_13
 // DotStar LED
-#define INTERNAL_DS_DATA     3
-#define INTERNAL_DS_CLK      4
-#define PIN_DOTSTAR_DATA     3
-#define PIN_DOTSTAR_CLK      4
-#define DOTSTAR_NUM          1
+#define INTERNAL_DS_DATA     (3u)
+#define INTERNAL_DS_CLK      (4u)
+#define PIN_DOTSTAR_DATA     (3u)
+#define PIN_DOTSTAR_CLK      (4u)
+#define DOTSTAR_NUM          (1u)
 
 /*
  * Analog pins

--- a/variants/gemma_m0/variant.h
+++ b/variants/gemma_m0/variant.h
@@ -87,6 +87,9 @@ extern "C"
 // DotStar LED
 #define INTERNAL_DS_DATA     3
 #define INTERNAL_DS_CLK      4
+#define PIN_DOTSTAR_DATA     3
+#define PIN_DOTSTAR_CLK      4
+#define DOTSTAR_NUM          1
 
 /*
  * Analog pins

--- a/variants/itsybitsy_m0/variant.h
+++ b/variants/itsybitsy_m0/variant.h
@@ -80,6 +80,10 @@ extern "C"
 #define PIN_LED_13           (13u)
 #define PIN_LED              PIN_LED_13
 #define LED_BUILTIN          PIN_LED_13
+// DotStar LED
+#define PIN_DOTSTAR_DATA     41
+#define PIN_DOTSTAR_CLK      40
+#define DOTSTAR_NUM          1
 
 /*
  * Analog pins

--- a/variants/itsybitsy_m0/variant.h
+++ b/variants/itsybitsy_m0/variant.h
@@ -81,9 +81,9 @@ extern "C"
 #define PIN_LED              PIN_LED_13
 #define LED_BUILTIN          PIN_LED_13
 // DotStar LED
-#define PIN_DOTSTAR_DATA     41
-#define PIN_DOTSTAR_CLK      40
-#define DOTSTAR_NUM          1
+#define PIN_DOTSTAR_DATA     (41u)
+#define PIN_DOTSTAR_CLK      (40u)
+#define DOTSTAR_NUM          (1u)
 
 /*
  * Analog pins

--- a/variants/itsybitsy_m4/variant.h
+++ b/variants/itsybitsy_m4/variant.h
@@ -84,6 +84,10 @@ extern "C"
 #define PIN_LED_13           (13u)
 #define PIN_LED              PIN_LED_13
 #define LED_BUILTIN          PIN_LED_13
+// DotStar LED
+#define PIN_DOTSTAR_DATA     8
+#define PIN_DOTSTAR_CLK      6
+#define DOTSTAR_NUM          1
 
 /*
  * Analog pins
@@ -137,7 +141,7 @@ static const uint8_t ATN = PIN_ATN;
 #define PAD_SPI_TX           SPI_PAD_0_SCK_1
 #define PAD_SPI_RX           SERCOM_RX_PAD_3
 
-static const uint8_t SS	  = PIN_A2 ;	
+static const uint8_t SS	  = PIN_A2 ;
 static const uint8_t MOSI = PIN_SPI_MOSI ;
 static const uint8_t MISO = PIN_SPI_MISO ;
 static const uint8_t SCK  = PIN_SPI_SCK ;

--- a/variants/itsybitsy_m4/variant.h
+++ b/variants/itsybitsy_m4/variant.h
@@ -85,9 +85,9 @@ extern "C"
 #define PIN_LED              PIN_LED_13
 #define LED_BUILTIN          PIN_LED_13
 // DotStar LED
-#define PIN_DOTSTAR_DATA     8
-#define PIN_DOTSTAR_CLK      6
-#define DOTSTAR_NUM          1
+#define PIN_DOTSTAR_DATA     (8u)
+#define PIN_DOTSTAR_CLK      (6u)
+#define DOTSTAR_NUM          (1u)
 
 /*
  * Analog pins

--- a/variants/trinket_m0/variant.h
+++ b/variants/trinket_m0/variant.h
@@ -87,6 +87,9 @@ extern "C"
 // DotStar LED
 #define INTERNAL_DS_DATA     7
 #define INTERNAL_DS_CLK      8
+#define PIN_DOTSTAR_DATA     7
+#define PIN_DOTSTAR_CLK      8
+#define DOTSTAR_NUM          1
 
 /*
  * Analog pins

--- a/variants/trinket_m0/variant.h
+++ b/variants/trinket_m0/variant.h
@@ -85,11 +85,11 @@ extern "C"
 #define PIN_LED3             PIN_LED_TXL
 #define LED_BUILTIN          PIN_LED_13
 // DotStar LED
-#define INTERNAL_DS_DATA     7
-#define INTERNAL_DS_CLK      8
-#define PIN_DOTSTAR_DATA     7
-#define PIN_DOTSTAR_CLK      8
-#define DOTSTAR_NUM          1
+#define INTERNAL_DS_DATA     (7u)
+#define INTERNAL_DS_CLK      (8u)
+#define PIN_DOTSTAR_DATA     (7u)
+#define PIN_DOTSTAR_CLK      (8u)
+#define DOTSTAR_NUM          (1u)
 
 /*
  * Analog pins


### PR DESCRIPTION
For #320.

- Existing `#defs` left in place.
- Not seeing a variant for PyRuler - it's just a Trinket M0, right?