### PR TITLE
Proposal to improve WVariant part number define logic

### DIFF
--- a/cores/arduino/WVariant.h
+++ b/cores/arduino/WVariant.h
@@ -136,7 +136,7 @@ typedef enum _ETCChannel
   TC7_CH1 =  (12<<8)|(1),
 } ETCChannel ;
 
-#elif defined(__SAMD51P19A__) || defined(__SAMD51P20A__)
+#elif defined(__SAME53N20A__) || defined(__SAME53N19A__) || defined(__SAME54P20A__) || defined(__SAME54P19A__) || defined(__SAME54N20A__) || defined(__SAME54N19A__) || defined(__SAMD51P20A__) || defined(__SAMD51P19A__) || defined(__SAMD51N20A__) || defined(__SAMD51N19A__) || defined(__SAME51N20A__) || defined(__SAME51N19A__)
 
 typedef enum _ETCChannel
 {

--- a/cores/arduino/cortex_handlers.c
+++ b/cores/arduino/cortex_handlers.c
@@ -133,6 +133,7 @@ void USB_0_Handler               ( void ) __attribute__ ((weak));
 void USB_1_Handler               ( void ) __attribute__ ((weak));
 void USB_2_Handler               ( void ) __attribute__ ((weak));
 void USB_3_Handler               ( void ) __attribute__ ((weak));
+void GMAC_Handler                ( void ) __attribute__ ((weak, alias("Dummy_Handler")));
 void TCC0_0_Handler              ( void ) __attribute__ ((weak, alias("Dummy_Handler")));
 void TCC0_1_Handler              ( void ) __attribute__ ((weak, alias("Dummy_Handler")));
 void TCC0_2_Handler              ( void ) __attribute__ ((weak, alias("Dummy_Handler")));
@@ -302,7 +303,7 @@ __attribute__ ((section(".isr_vector"))) const DeviceVectors exception_table =
 	  (void*) USB_1_Handler,                 /* 81 Universal Serial Bus IRQ 1 */
 	  (void*) USB_2_Handler,                 /* 82 Universal Serial Bus IRQ 2 */
 	  (void*) USB_3_Handler,                 /* 83 Universal Serial Bus IRQ 3 */
-	  (void*) (0UL),
+	  (void*) GMAC_Handler,					 /* 84 Ethernet MAC */
 	  (void*) TCC0_0_Handler,                /* 85 Timer Counter Control 0 IRQ 0 */
 	  (void*) TCC0_1_Handler,                /* 86 Timer Counter Control 0 IRQ 1 */
 	  (void*) TCC0_2_Handler,                /* 87 Timer Counter Control 0 IRQ 2 */


### PR DESCRIPTION
I needed this hacky fix to build with the SAME54N20A. Is there a way to use the CMSIS definitions to automatically build the correct list of _ETCChannel enum options? I will try to explore soon. I've managed to get everything building with forks of all the adafruit repos, but I'd rather not have to maintain that complexity if I can help the upstream support a wider range of parts.