### PR TITLE
add PIN_DOTSTAR_CLOCK

### DIFF
--- a/variants/gemma_m0/variant.h
+++ b/variants/gemma_m0/variant.h
@@ -89,6 +89,7 @@ extern "C"
 #define INTERNAL_DS_CLK      (4u)
 #define PIN_DOTSTAR_DATA     (3u)
 #define PIN_DOTSTAR_CLK      (4u)
+#define PIN_DOTSTAR_CLOCK    PIN_DOTSTAR_CLK
 #define DOTSTAR_NUM          (1u)
 
 /*

--- a/variants/itsybitsy_m0/variant.h
+++ b/variants/itsybitsy_m0/variant.h
@@ -83,6 +83,7 @@ extern "C"
 // DotStar LED
 #define PIN_DOTSTAR_DATA     (41u)
 #define PIN_DOTSTAR_CLK      (40u)
+#define PIN_DOTSTAR_CLOCK    PIN_DOTSTAR_CLK
 #define DOTSTAR_NUM          (1u)
 
 /*

--- a/variants/itsybitsy_m4/variant.h
+++ b/variants/itsybitsy_m4/variant.h
@@ -87,6 +87,7 @@ extern "C"
 // DotStar LED
 #define PIN_DOTSTAR_DATA     (8u)
 #define PIN_DOTSTAR_CLK      (6u)
+#define PIN_DOTSTAR_CLOCK    PIN_DOTSTAR_CLK
 #define DOTSTAR_NUM          (1u)
 
 /*

--- a/variants/trinket_m0/variant.h
+++ b/variants/trinket_m0/variant.h
@@ -89,6 +89,7 @@ extern "C"
 #define INTERNAL_DS_CLK      (8u)
 #define PIN_DOTSTAR_DATA     (7u)
 #define PIN_DOTSTAR_CLK      (8u)
+#define PIN_DOTSTAR_CLOCK    PIN_DOTSTAR_CLK
 #define DOTSTAR_NUM          (1u)
 
 /*


### PR DESCRIPTION
This is a follow up PR to #321. The goal is to be able to add a new single example for using a board with a built in DotStar that utilizes these defines. So they all need to be the same.

Other BSP's use `PIN_DOTSTAR_CLOCK`. So adding that as well. 

ESP32:
https://github.com/espressif/arduino-esp32/blob/8fe0efe8c0bb462cf0c5472d34dcae11ce4819c2/variants/adafruit_funhouse_esp32s2/pins_arduino.h#L30 

nRF52:
https://github.com/adafruit/Adafruit_nRF52_Arduino/blob/10ed826056f9c0b3079129a3ec37c3a90ecb0585/variants/itsybitsy_nrf52840_express/variant.h#L48