### PR TITLE
Add .ramfunc attribute to flash_with_bootloader.ld to enable keeping functions in RAM

### DIFF
--- a/variants/feather_m4/linker_scripts/gcc/flash_with_bootloader.ld
+++ b/variants/feather_m4/linker_scripts/gcc/flash_with_bootloader.ld
@@ -170,6 +170,10 @@ SECTIONS
 		KEEP(*(.fini_array))
 		PROVIDE_HIDDEN (__fini_array_end = .);
 
+		. = ALIGN(4);
+		/* Keep .ramfunc functions in RAM */
+		KEEP(*(.ramfunc))
+
 		KEEP(*(.jcr*))
 		. = ALIGN(16);
 		/* All data end */


### PR DESCRIPTION
For some use cases, e.g. re-flashing the Arduino during runtime via OTA updates, it is useful to enable certain functions to be kept in RAM so that the underlying flash memory may be replaced with new firmware while the program is running. An approach to accomplishing this is to [prefix function definitions with the .ramfunc attribute](https://forum.arduino.cc/t/how-to-execute-code-from-ram/409708):

`__attribute__ ((long_call, section (".ramfunc")))`

However, to get this to work, we needed to add a section specifying how to handle `.ramfunc` to the relevant `flash_with_bootloader.ld` for our hardware.

Is this the correct entry point? If so, is this few line addition appropriate for inclusion in this repository? In this PR, I've only added the line to the `feather_m4` variant, though it could also be added for architectures.
