### PR TITLE
PyPortal: fix SS pin definition

### DIFF
--- a/variants/pyportal_m4/variant.h
+++ b/variants/pyportal_m4/variant.h
@@ -160,7 +160,7 @@ static const uint8_t ATN = PIN_ATN;
 #define PAD_SPI_TX           SPI_PAD_0_SCK_1
 #define PAD_SPI_RX           SERCOM_RX_PAD_2
 
-static const uint8_t SS	  = PIN_A2;       // ???
+static const uint8_t SS	  = 32;
 static const uint8_t MOSI = PIN_SPI_MOSI;
 static const uint8_t MISO = PIN_SPI_MISO;
 static const uint8_t SCK  = PIN_SPI_SCK;

--- a/variants/pyportal_m4_titano/variant.h
+++ b/variants/pyportal_m4_titano/variant.h
@@ -160,7 +160,7 @@ static const uint8_t ATN = PIN_ATN;
 #define PAD_SPI_TX           SPI_PAD_0_SCK_1
 #define PAD_SPI_RX           SERCOM_RX_PAD_2
 
-static const uint8_t SS	  = PIN_A2;       // ???
+static const uint8_t SS	  = 32;
 static const uint8_t MOSI = PIN_SPI_MOSI;
 static const uint8_t MISO = PIN_SPI_MISO;
 static const uint8_t SCK  = PIN_SPI_SCK;


### PR DESCRIPTION
When using the PyPortal I noticed that the `SS` pin was set to `PIN_A2` (pin 16 I think). I believe that `SS` usually refers to the slave select line which in the case of the SD card is pin `32`. As per the `//???` comment I presumed this to be a mistake and am submitting this simple PR as a simple fix. 

For reference here is the PyPortal Titano's pinout:
![img](https://cdn-learn.adafruit.com/assets/assets/000/111/879/original/adafruit_products_Adafruit_PyPortal_Titano_Pinout.png)