### PR TITLE
fix sendStringDescriptor() maxlen uitn8_t to uint32_t

### DIFF
--- a/cores/arduino/USB/USBAPI.h
+++ b/cores/arduino/USB/USBAPI.h
@@ -85,7 +85,7 @@ public:
 	uint32_t sendControl(int /* ep */, const void *data, uint32_t len) { return sendControl(data, len); }
 	uint32_t recvControl(void *data, uint32_t len);
 	uint32_t sendConfiguration(uint32_t maxlen);
-	bool sendStringDescriptor(const uint8_t *string, uint8_t maxlen);
+	bool sendStringDescriptor(const uint8_t *string, uint32_t maxlen);
 	void initControl(int end);
 	uint8_t SendInterfaces(uint32_t* total);
 	void packMessages(bool val);

--- a/cores/arduino/USB/USBCore.cpp
+++ b/cores/arduino/USB/USBCore.cpp
@@ -110,12 +110,12 @@ static EPHandler *epHandlers[7] = {NULL, NULL, NULL, NULL, NULL, NULL, NULL};
 // Send a USB descriptor string. The string is stored as a
 // plain ASCII string but is sent out as UTF-16 with the
 // correct 2-byte prefix
-bool USBDeviceClass::sendStringDescriptor(const uint8_t *string, uint8_t maxlen)
+bool USBDeviceClass::sendStringDescriptor(const uint8_t *string, uint32_t maxlen)
 {
 	if (maxlen < 2)
 		return false;
 
-	uint8_t buffer[maxlen];
+	uint8_t* buffer = (uint8_t*)malloc(maxlen);
 	buffer[0] = strlen((const char*)string) * 2 + 2;
 	buffer[1] = 0x03;
 
@@ -126,7 +126,9 @@ bool USBDeviceClass::sendStringDescriptor(const uint8_t *string, uint8_t maxlen)
 		buffer[i] = 0;
 	}
 
-	return USBDevice.sendControl(buffer, i);
+	bool ret = USBDevice.sendControl(buffer, i);
+	free(buffer);
+	return ret;
 }
 
 bool _dry_run = false;


### PR DESCRIPTION
fix #350 change sendStringDescriptor() maxlen from uint8_t to uint32_t following upstream