### PR TITLE
Fix hangs when transfer errors occur

### DIFF
--- a/cores/arduino/SERCOM.cpp
+++ b/cores/arduino/SERCOM.cpp
@@ -561,7 +561,8 @@ bool SERCOM::startTransmissionWIRE(uint8_t address, SercomWireReadWriteFlag flag
       // Wait transmission complete
 
 		// If certain errors occur, the MB bit may never be set (RFTM: SAMD21 sec:28.10.6; SAMD51 sec:36.10.7).
-		// There are additional errors that can occur (including BUSERR) that are rolled up in INTFLAG.ERROR
+    	// The data transfer errors that can occur (including BUSERR) are all
+		// rolled up into INTFLAG.bit.ERROR from STATUS.reg
 		if (sercom->I2CM.INTFLAG.bit.ERROR) {
 		  return false;
 		}
@@ -605,9 +606,10 @@ bool SERCOM::sendDataMasterWIRE(uint8_t data)
   //Wait transmission successful
   while(!sercom->I2CM.INTFLAG.bit.MB) {
 
-    // If a bus error occurs, the MB bit may never be set.
-    // Check the bus error bit and bail if it's set.
-    // There are additional errors that can occur (including BUSERR) that are rolled up in INTFLAG.ERROR
+    // If a data transfer error occurs, the MB bit may never be set.
+    // Check the error bit and bail if it's set.
+    // The data transfer errors that can occur (including BUSERR) are all
+	// rolled up into INTFLAG.bit.ERROR from STATUS.reg
     if (sercom->I2CM.INTFLAG.bit.ERROR) {
       return false;
     }
@@ -715,7 +717,7 @@ uint8_t SERCOM::readDataWIRE( void )
 	  // A variety of errors in the STATUS register can set the ERROR bit in the INTFLAG register
       // In that case, send a stop condition and return false.
 	  // readDataWIRE should really be able to indicate an error (which would never be used
-	  // because the readDataWIRE caller should have checked availableWIRE() first and timed it 
+	  // because the readDataWIRE callers (in Wire.cpp) should have checked availableWIRE() first and timed it 
 	  // out if the data never showed up
         if (sercom->I2CM.INTFLAG.bit.ERROR || sercom->I2CM.INTFLAG.bit.MB) {
             sercom->I2CM.CTRLB.bit.CMD = 3; // Stop condition


### PR DESCRIPTION
This patch fixes hangs that can occur with certain I2C devices.  These where observed in a weather station running a Metro M4 Express.  It uses a number of I2C sensors including  HM3301 particle monitors (with 29 byte responses) and a PCA9615 bus extender.  I was having hangs about once a day.  Using the Watch Dog Timer, I was able to locate places where the code was not check for other error conditions while waiting for the SERCOM I2C controller.  These fixes have eliminated these hangs.