### PR TITLE
same51g19a: Fix missing ETC channel definitions in WVariant

### DIFF
--- a/cores/arduino/WVariant.h
+++ b/cores/arduino/WVariant.h
@@ -63,7 +63,7 @@ typedef enum _EAnalogChannel
 
 #if defined(__SAMD51__)
 
-#if defined(__SAMD51G19A__)
+#if defined(__SAMD51G19A__) || defined(__SAME51G19A__)
 
 typedef enum _ETCChannel
 {


### PR DESCRIPTION
When using the SAME51G19A I noticed there are not the correct TCC and TC definitions. The J19A version of the same board correctly defines them equal to the equivalent SAMD51 MCU. This change does the same for the G19A.