### PR TITLE
Sercom: partially revert error handling change

### DIFF
--- a/cores/arduino/SERCOM.cpp
+++ b/cores/arduino/SERCOM.cpp
@@ -605,9 +605,7 @@ bool SERCOM::sendDataMasterWIRE(uint8_t data)
   while(!sercom->I2CM.INTFLAG.bit.MB) {
     // If a data transfer error occurs, the MB bit may never be set.
     // Check the error bit and bail if it's set.
-    // The data transfer errors that can occur (including BUSERR) are all
-    // rolled up into INTFLAG.bit.ERROR from STATUS.reg
-    if (sercom->I2CM.INTFLAG.bit.ERROR) {
+    if (sercom->I2CM.STATUS.bit.BUSERR) {
       return false;
     }
   }


### PR DESCRIPTION
Revert a part of ccfc7db988fe2f61dd3f8734794fa9f69730f58d. It breaks I2C communcation.

https://github.com/adafruit/ArduinoCore-samd/issues/376