### PR TITLE
Define PIN_NEOPIXEL for NeoPixel support

### DIFF
--- a/variants/metro_m4/variant.h
+++ b/variants/metro_m4/variant.h
@@ -88,7 +88,7 @@ extern "C"
 #define PIN_LED2             PIN_LED_RXL
 #define PIN_LED3             PIN_LED_TXL
 #define LED_BUILTIN          PIN_LED_13
-#define PIN_NEOPIXEL         (40)
+#define PIN_NEOPIXEL         (40u)
 
 /*
  * Analog pins

--- a/variants/metro_m4_airlift/variant.h
+++ b/variants/metro_m4_airlift/variant.h
@@ -88,6 +88,7 @@ extern "C"
 #define PIN_LED2             PIN_LED_RXL
 #define PIN_LED3             PIN_LED_TXL
 #define LED_BUILTIN          PIN_LED_13
+#define PIN_NEOPIXEL         (40)
 
 /*
  * Analog pins

--- a/variants/metro_m4_airlift/variant.h
+++ b/variants/metro_m4_airlift/variant.h
@@ -88,7 +88,7 @@ extern "C"
 #define PIN_LED2             PIN_LED_RXL
 #define PIN_LED3             PIN_LED_TXL
 #define LED_BUILTIN          PIN_LED_13
-#define PIN_NEOPIXEL         (40)
+#define PIN_NEOPIXEL         (40u)
 
 /*
  * Analog pins


### PR DESCRIPTION
Adds the NeoPixel pin def to the M4 Airlift variant
`#define PIN_NEOPIXEL         (40)`